### PR TITLE
reorganize `#include`s

### DIFF
--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdlib>
+#include <ctype.h>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -15,6 +17,7 @@
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
+#include <stdio.h>
 #include <string>
 
 static String OUT_DIR;

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -5,6 +5,7 @@
 #include "Global.hpp"
 
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <span>
 

--- a/src/Cmd/Clean.cc
+++ b/src/Cmd/Clean.cc
@@ -3,9 +3,9 @@
 #include "../Logger.hpp"
 #include "Global.hpp"
 
+#include <cstdlib>
 #include <iostream>
 #include <span>
-#include <string>
 
 int cleanMain(std::span<const StringRef> args) noexcept {
   Path outDir = "poac-out";

--- a/src/Cmd/Clean.cc
+++ b/src/Cmd/Clean.cc
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <span>
+#include <string>
 
 int cleanMain(std::span<const StringRef> args) noexcept {
   Path outDir = "poac-out";

--- a/src/Cmd/Global.cc
+++ b/src/Cmd/Global.cc
@@ -4,6 +4,7 @@
 #include "../TermColor.hpp"
 
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 
 void printHeader(StringRef header) noexcept {

--- a/src/Cmd/Init.cc
+++ b/src/Cmd/Init.cc
@@ -4,6 +4,7 @@
 #include "Global.hpp"
 #include "New.hpp"
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <span>

--- a/src/Cmd/New.cc
+++ b/src/Cmd/New.cc
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <span>
 #include <stdexcept>
+#include <string>
 
 static inline constexpr StringRef mainCc =
     "#include <iostream>\n\n"

--- a/src/Cmd/New.cc
+++ b/src/Cmd/New.cc
@@ -4,12 +4,15 @@
 #include "../Rustify.hpp"
 #include "Global.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
+#include <ctype.h>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <span>
 #include <stdexcept>
-#include <string>
 
 static inline constexpr StringRef mainCc =
     "#include <iostream>\n\n"

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -5,6 +5,7 @@
 #include "Global.hpp"
 
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <span>
 

--- a/src/Cmd/Version.cc
+++ b/src/Cmd/Version.cc
@@ -3,6 +3,7 @@
 #include "../Logger.hpp"
 #include "Global.hpp"
 
+#include <cstdlib>
 #include <iostream>
 #include <span>
 

--- a/src/Manifest.cc
+++ b/src/Manifest.cc
@@ -6,7 +6,6 @@
 
 #include <cctype>
 #include <cstdlib>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 

--- a/src/TermColor.cc
+++ b/src/TermColor.cc
@@ -1,5 +1,7 @@
 #include "TermColor.hpp"
 
+#include <cstdlib>
+
 static bool isTerm() noexcept {
   return std::getenv("TERM") != nullptr;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,11 +14,12 @@
 #include "./Rustify.hpp"
 #include "./TermColor.hpp"
 
+#include <algorithm>
 #include <cstdlib>
-#include <iomanip>
+#include <ctype.h>
+#include <exception>
 #include <iostream>
 #include <span>
-#include <stdexcept>
 
 struct Cmd {
   Fn<int(std::span<const StringRef>)> main;


### PR DESCRIPTION
reorganizing `#include`s using [IWYU](https://github.com/include-what-you-use/include-what-you-use) except for headers within `Rustify.hpp`

- Note
  - `::tolower` and `::toupper` are not guaranteed to be declared in `<cctype>` header, so there are two options:

    - **option1**: include `<ctype.h>` instead
    - **option2**: rewite those to like `[](auto c) { return std::toupper(c); }`

    This PR took **option1** because the purpose of this is just organizing `#include`s.