### PR TITLE
Solved non-dependency warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INSTALL ?= install
 
 DEBUG_FLAGS := -g -O0 -DDEBUG
 RELEASE_FLAGS := -O3 -DNDEBUG
-CXXFLAGS := -Wall -Wextra -fdiagnostics-color -pedantic-errors -std=c++20
+CXXFLAGS := -Wall -Wextra -Wpedantic -Wconversion -fdiagnostics-color -pedantic-errors -std=c++20
 ifeq ($(RELEASE), 1)
 	CXXFLAGS += $(RELEASE_FLAGS)
 else

--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -185,7 +185,8 @@ static void emitTarget(
   for (StringRef dep : dependsOn) {
     if (offset + dep.size() + 2 > 80) { // 2 for space and \.
       // \ for line continuation. \ is the 80th character.
-      os << std::setw(83 - offset) << " \\\n ";
+      os << std::setw(static_cast<i32>(83) - offset) << " \\\n ";
+
       offset = 2;
     }
     os << " " << dep;

--- a/src/VersionReq.cc
+++ b/src/VersionReq.cc
@@ -35,7 +35,11 @@ String to_string(const Comparator::Op op) noexcept {
       return "<";
     case Comparator::Lte:
       return "<=";
+    // a good solution would be to have a default case here with an assertion that fails in Debug builds
+    // so that we have a warning if a value goes unhandled (the current solution invokes UB)
   }
+  // tells the compiler that the above switch is fully specified, therefore getting to this point is undefined behaviour
+  __builtin_unreachable();
 }
 
 struct OptVersion {
@@ -371,7 +375,10 @@ bool Comparator::satisfiedBy(const Version& ver) const noexcept {
       return matchesLess(*this, ver);
     case Op::Lte:
       return matchesExact(*this, ver) || matchesLess(*this, ver);
+    // a good solution would be to have a default case here with an assertion that fails in Debug builds
+    // so that we have a warning if a value goes unhandled (the current solution invokes UB)
   }
+  __builtin_unreachable(); // tell the compiler that the switch covers all cases
 }
 
 Comparator Comparator::canonicalize() const noexcept {


### PR DESCRIPTION
## Why there were warnings

On my machine (gcc version 13.2.1 20230801 (GCC)) compiling `poac` threw a few inconsequential warnings due to the fact that `Comparator::Op` is not an `enum class` but a raw enum. This leads the compiler to allow any integer to be passed to `to_string(Comparator::Op op)`, meaning that for some branches that non-void function could return void.

## Proposed solution

`poac` currently has no policy to deal with this so, to suppress warnings, I added `__builtin_unreachable()` just after the switch. this means that we now tell the compiler that exiting the switch without a return is *impossible*, therefore it is undefined behaviour and he is free to optimize that away.

I did not want to make any more complex decisions since I am not active part of the development of poac, but I suggest a solution that also warns on debug builds:

```cpp

switch(var) {
  case 0:
    return ...;
  default:
    #ifdef POAC_DEBUG
      assert("to_string called with invalid enum");
    #else 
      __builtin_unreachable();
    #endif // POAC_DEBUG 
}
```

## Additional changes

I also tried to trigger more warnings by adding `-Wconversion` and `-Wpedantic`, but nothing came up except a conversion from `uint` to `int` which stems from an old `iostream` function taking `int`s when it should really take `uint` instead. That's fixed too.

p.s: there is still one single warning remaining coming from the toml parser dependency, `poac` itself is warning-free after this pull request!