### PR TITLE
changed every `cout` to `cerr`

### DIFF
--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -172,8 +172,8 @@ struct BuildConfig {
     all = dependsOn;
   }
 
-  void emitMakefile(std::ostream& = std::cout) const;
-  void emitCompdb(const StringRef, std::ostream& = std::cout) const;
+  void emitMakefile(std::ostream& = std::cerr) const;
+  void emitCompdb(const StringRef, std::ostream& = std::cerr) const;
 };
 
 static void

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -70,10 +70,10 @@ buildMain(const std::span<const StringRef> args) {
 
 void
 buildHelp() noexcept {
-  std::cout << buildDesc << '\n';
-  std::cout << '\n';
+  std::cerr << buildDesc << '\n';
+  std::cerr << '\n';
   printUsage("build", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--debug", "-d", "Build with debug information [default]");

--- a/src/Cmd/Clean.cc
+++ b/src/Cmd/Clean.cc
@@ -47,10 +47,10 @@ cleanMain(const std::span<const StringRef> args) noexcept {
 
 void
 cleanHelp() noexcept {
-  std::cout << cleanDesc << '\n';
-  std::cout << '\n';
+  std::cerr << cleanDesc << '\n';
+  std::cerr << '\n';
   printUsage("clean", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption(

--- a/src/Cmd/Fmt.cc
+++ b/src/Cmd/Fmt.cc
@@ -100,10 +100,10 @@ fmtMain(const std::span<const StringRef> args) {
 
 void
 fmtHelp() noexcept {
-  std::cout << fmtDesc << '\n';
-  std::cout << '\n';
+  std::cerr << fmtDesc << '\n';
+  std::cerr << '\n';
   printUsage("fmt", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--check", "", "Run clang-format in check mode");

--- a/src/Cmd/Global.cc
+++ b/src/Cmd/Global.cc
@@ -10,16 +10,16 @@
 
 void
 printHeader(const StringRef header) noexcept {
-  std::cout << bold(green(header)) << '\n';
+  std::cerr << bold(green(header)) << '\n';
 }
 
 void
 printUsage(const StringRef cmd, const StringRef usage) noexcept {
-  std::cout << bold(green("Usage: ")) << bold(cyan("poac "));
+  std::cerr << bold(green("Usage: ")) << bold(cyan("poac "));
   if (!cmd.empty()) {
-    std::cout << bold(cyan(cmd)) << ' ';
+    std::cerr << bold(cyan(cmd)) << ' ';
   }
-  std::cout << cyan(usage) << '\n';
+  std::cerr << cyan(usage) << '\n';
 }
 
 void
@@ -40,19 +40,19 @@ printOption(
   option += cyan(placeholder);
 
   if (shouldColor()) {
-    std::cout << "  " << std::left << std::setw(69) << option << desc << '\n';
+    std::cerr << "  " << std::left << std::setw(69) << option << desc << '\n';
   } else {
-    std::cout << "  " << std::left << std::setw(26) << option << desc << '\n';
+    std::cerr << "  " << std::left << std::setw(26) << option << desc << '\n';
   }
 }
 
 void
 printCommand(const StringRef name, const StringRef desc) noexcept {
   if (shouldColor()) {
-    std::cout << "  " << std::left << std::setw(27) << bold(cyan(name)) << desc
+    std::cerr << "  " << std::left << std::setw(27) << bold(cyan(name)) << desc
               << '\n';
   } else {
-    std::cout << "  " << std::left << std::setw(10) << name << desc << '\n';
+    std::cerr << "  " << std::left << std::setw(10) << name << desc << '\n';
   }
 }
 

--- a/src/Cmd/Help.cc
+++ b/src/Cmd/Help.cc
@@ -6,13 +6,13 @@
 
 void
 helpHelp() noexcept {
-  std::cout << helpDesc << '\n';
-  std::cout << '\n';
+  std::cerr << helpDesc << '\n';
+  std::cerr << '\n';
   printUsage("help", "[OPTIONS] [COMMAND]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Arguments:");
-  std::cout << "  [COMMAND]" << '\n';
+  std::cerr << "  [COMMAND]" << '\n';
 }

--- a/src/Cmd/Init.cc
+++ b/src/Cmd/Init.cc
@@ -52,10 +52,10 @@ initMain(const std::span<const StringRef> args) {
 
 void
 initHelp() noexcept {
-  std::cout << initDesc << '\n';
-  std::cout << '\n';
+  std::cerr << initDesc << '\n';
+  std::cerr << '\n';
   printUsage("init", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--bin", "-b", "Use a binary (application) template [default]");

--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -110,10 +110,10 @@ lintMain(const std::span<const StringRef> args) {
 
 void
 lintHelp() noexcept {
-  std::cout << lintDesc << '\n';
-  std::cout << '\n';
+  std::cerr << lintDesc << '\n';
+  std::cerr << '\n';
   printUsage("lint", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--exclude", "", "Exclude files from linting");

--- a/src/Cmd/New.cc
+++ b/src/Cmd/New.cc
@@ -19,7 +19,7 @@
 static inline constexpr StringRef MAIN_CC =
     "#include <iostream>\n\n"
     "int main() {\n"
-    "  std::cout << \"Hello, world!\" << std::endl;\n"
+    "  std::cerr << \"Hello, world!\" << std::endl;\n"
     "}\n";
 
 static String
@@ -201,15 +201,15 @@ newMain(const std::span<const StringRef> args) {
 
 void
 newHelp() noexcept {
-  std::cout << newDesc << '\n';
-  std::cout << '\n';
+  std::cerr << newDesc << '\n';
+  std::cerr << '\n';
   printUsage("new", "[OPTIONS] <name>");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--bin", "-b", "Use a binary (application) template [default]");
   printOption("--lib", "-l", "Use a library template");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Arguments:");
-  std::cout << "  <name>" << '\n';
+  std::cerr << "  <name>" << '\n';
 }

--- a/src/Cmd/Run.cc
+++ b/src/Cmd/Run.cc
@@ -48,16 +48,16 @@ runMain(const std::span<const StringRef> args) {
 
 void
 runHelp() noexcept {
-  std::cout << runDesc << '\n';
-  std::cout << '\n';
+  std::cerr << runDesc << '\n';
+  std::cerr << '\n';
   printUsage("run", "[OPTIONS] [args]...");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--debug", "-d", "Build with debug information [default]");
   printOption("--release", "-r", "Build with optimizations");
   printOption("--no-parallel", "", "Disable parallel builds");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Arguments:");
-  std::cout << "  [args]...\tArguments passed to the program" << '\n';
+  std::cerr << "  [args]...\tArguments passed to the program" << '\n';
 }

--- a/src/Cmd/Search.cc
+++ b/src/Cmd/Search.cc
@@ -91,15 +91,15 @@ searchMain(const std::span<const StringRef> args) {
     return EXIT_SUCCESS;
   }
 
-  std::cout << std::left << std::setw(30) << "Name" << std::setw(10)
+  std::cerr << std::left << std::setw(30) << "Name" << std::setw(10)
             << "Version" << std::setw(50) << "Description" << '\n';
-  std::cout << String(80, '-') << '\n';
+  std::cerr << String(80, '-') << '\n';
   for (const auto& package : packages) {
     const String name = package["name"];
     const String version = package["version"];
     const String description = package["description"];
 
-    std::cout << std::left << std::setw(30) << name << std::setw(10) << version
+    std::cerr << std::left << std::setw(30) << name << std::setw(10) << version
               << std::setw(50) << description << '\n';
   }
 
@@ -108,10 +108,10 @@ searchMain(const std::span<const StringRef> args) {
 
 void
 searchHelp() noexcept {
-  std::cout << searchDesc << '\n';
-  std::cout << '\n';
+  std::cerr << searchDesc << '\n';
+  std::cerr << '\n';
   printUsage("search", "[OPTIONS] <name>");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption(
@@ -121,7 +121,7 @@ searchHelp() noexcept {
   printOption(
       "--page", "", "Page number of results to show [default: 1]", "<NUM>"
   );
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Arguments:");
-  std::cout << "  <name>" << '\n';
+  std::cerr << "  <name>" << '\n';
 }

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -57,10 +57,10 @@ testMain(const std::span<const StringRef> args) {
 
 void
 testHelp() noexcept {
-  std::cout << testDesc << '\n';
-  std::cout << '\n';
+  std::cerr << testDesc << '\n';
+  std::cerr << '\n';
   printUsage("test", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
   printOption("--debug", "-d", "Test with debug information [default]");

--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -47,10 +47,10 @@ tidyMain(const std::span<const StringRef> args) {
 
 void
 tidyHelp() noexcept {
-  std::cout << tidyDesc << '\n';
-  std::cout << '\n';
+  std::cerr << tidyDesc << '\n';
+  std::cerr << '\n';
   printUsage("tidy", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
 }

--- a/src/Cmd/Version.cc
+++ b/src/Cmd/Version.cc
@@ -97,16 +97,16 @@ versionMain(const std::span<const StringRef> args) noexcept {
     }
   }
 
-  std::cout << "poac " << POAC_VERSION << " (" << DATE << ")\n";
+  std::cerr << "poac " << POAC_VERSION << " (" << DATE << ")\n";
   return EXIT_SUCCESS;
 }
 
 void
 versionHelp() noexcept {
-  std::cout << versionDesc << '\n';
-  std::cout << '\n';
+  std::cerr << versionDesc << '\n';
+  std::cerr << '\n';
   printUsage("version", "[OPTIONS]");
-  std::cout << '\n';
+  std::cerr << '\n';
   printHeader("Options:");
   printGlobalOpts();
 }

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -33,18 +33,18 @@ struct Logger {
   }
   template <typename... Args>
   static void warn(Args&&... message) noexcept {
-    logln(std::cout, LogLevel::warning, std::forward<Args>(message)...);
+    logln(std::cerr, LogLevel::warning, std::forward<Args>(message)...);
   }
   template <typename T, typename... Args>
   static void info(T&& header, Args&&... message) noexcept {
     logln(
-        std::cout, LogLevel::info, std::forward<T>(header),
+        std::cerr, LogLevel::info, std::forward<T>(header),
         std::forward<Args>(message)...
     );
   }
   template <typename... Args>
   static void debug(Args&&... message) noexcept {
-    logln(std::cout, LogLevel::debug, std::forward<Args>(message)...);
+    logln(std::cerr, LogLevel::debug, std::forward<Args>(message)...);
   }
 
   template <typename T, typename... Args>

--- a/src/TestUtils.hpp
+++ b/src/TestUtils.hpp
@@ -53,7 +53,7 @@ pass(
     const StringRef f = __builtin_FILE(),
     const StringRef fn = __builtin_FUNCTION()
 ) noexcept {
-  std::cout << "test " << f << "::" << fn << " ... " << green("ok") << '\n'
+  std::cerr << "test " << f << "::" << fn << " ... " << green("ok") << '\n'
             << std::flush;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -78,15 +78,15 @@ helpMain(const std::span<const StringRef> args) noexcept {
   }
 
   // Print help message for poac itself
-  std::cout << "A package manager and build system for C++" << '\n';
-  std::cout << '\n';
+  std::cerr << "A package manager and build system for C++" << '\n';
+  std::cerr << '\n';
   printUsage("", "[OPTIONS] [COMMAND]");
-  std::cout << '\n';
+  std::cerr << '\n';
 
   printHeader("Options:");
   printGlobalOpts();
   printOption("--version", "-V", "Print version info and exit");
-  std::cout << '\n';
+  std::cerr << '\n';
 
   printHeader("Commands:");
   for (const auto& [name, cmd] : CMDS) {


### PR DESCRIPTION
As I'm concerned it's good practice to print log messages to `stderr` which is `std::cerr` in c++,
I changed every occurence of `cout` to `cerr`, because I found everything that was printed to `cout` a kind of log message.
If I'm wrong, correct me, but text like `Finished debug target(s) in 0.0457814s` really does belong to `stderr`.
Using `stderr` helps in situations e.g. when output of the program run by `poac` is redirected to a file, take this example: `poac run > output.txt`,
in which I suppose to see the output of my program, not things like `Compiling...`.
