### PR TITLE
Add installation instructions for Arch Linux based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ It is important to verify the package name and copy it accurately to prevent typ
 brew install poac
 ```
 
+#### AUR (Arch Linux)
+Poac is available in the AUR thanks to the [poac](https://aur.archlinux.org/packages/poac) package.
+
+It can be installed with the AUR helper of your choice.
+
+```sh
+paru -S poac
+```
+
 ### Build from source
 
 If your environment is not included in the released packages, you have to build Poac from the source. You will require the following compilers, commands, and libraries:


### PR DESCRIPTION
Hello, first of all I would like to thank you for this great project.

As maintainer of the AUR [poac](https://aur.archlinux.org/packages/poac) package, I think it might be useful for those using an Arch Linux-based distribution to know that they no longer need to manually compile the source code.

Please feel free to suggest improvements to the package if necessary. 