### PR TITLE
Fixed for libgit2 1.8

### DIFF
--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -49,4 +49,3 @@ git2Throw(const int ret) {
 }
 
 } // namespace git2
-

--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -46,4 +46,5 @@ git2Throw(const int ret) {
   }
   return ret;
 }
+
 } // namespace git2

--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -46,5 +46,4 @@ git2Throw(const int ret) {
   }
   return ret;
 }
-
 } // namespace git2

--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -2,7 +2,9 @@
 
 #include "../Rustify.hpp"
 
+#include <git2/deprecated.h>
 #include <git2/errors.h>
+
 #include <git2/version.h>
 
 namespace git2 {
@@ -25,7 +27,7 @@ Exception::Exception() {
   if (const git_error* error = git_error_last(); error != nullptr) {
     this->msg += error->message;
     this->cat = static_cast<git_error_t>(error->klass);
-    git_error_clear();
+    giterr_clear();
   }
 }
 
@@ -47,3 +49,4 @@ git2Throw(const int ret) {
 }
 
 } // namespace git2
+

--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -4,7 +4,6 @@
 
 #include <git2/deprecated.h>
 #include <git2/errors.h>
-
 #include <git2/version.h>
 
 namespace git2 {


### PR DESCRIPTION
Fixed for libgit2:1.8.0-2

```
The error functions and enumeration values have been renamed for consistency. The giterr_ functions and values prefix have been renamed to be prefixed with git_error_; similarly, the GITERR_ constants have been renamed to be prefixed with GIT_ERROR_. The old enumerations and macros will be retained for backward compatibility for the foreseeable future.
```
https://github.com/libgit2/libgit2/blob/main/docs/changelog.md