### PR TITLE
remove noexcept from `Manifest::instance()`

### DIFF
--- a/src/Manifest.cc
+++ b/src/Manifest.cc
@@ -144,7 +144,7 @@ struct Manifest {
   Manifest& operator=(Manifest&&) noexcept = delete;
   ~Manifest() noexcept = default;
 
-  static Manifest& instance() noexcept {
+  static Manifest& instance() {
     static Manifest instance;
     instance.load();
     return instance;


### PR DESCRIPTION
fixes #927

`Manifest::load()` might throw exceptions, but `Manifest::instance()` calls it unconditionally though it is specified to `noexcept`.
