### PR TITLE
Allow `.` and `++` in dependency names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SRCS := $(shell find src -name '*.cc')
 OBJS := $(patsubst src/%,$(O)/%,$(SRCS:.cc=.o))
 DEPS := $(OBJS:.o=.d)
 
-UNITTEST_SRCS := src/BuildConfig.cc src/Algos.cc src/Semver.cc src/VersionReq.cc
+UNITTEST_SRCS := src/BuildConfig.cc src/Algos.cc src/Semver.cc src/VersionReq.cc src/Manifest.cc
 UNITTEST_OBJS := $(patsubst src/%,$(O)/tests/test_%,$(UNITTEST_SRCS:.cc=.o))
 UNITTEST_BINS := $(UNITTEST_OBJS:.o=)
 UNITTEST_DEPS := $(UNITTEST_OBJS:.o=.d)
@@ -69,6 +69,7 @@ test: $(UNITTEST_BINS)
 	@$(O)/tests/test_Algos
 	@$(O)/tests/test_Semver
 	@$(O)/tests/test_VersionReq
+	@$(O)/tests/test_Manifest
 
 $(O)/tests/test_%.o: src/%.cc $(GIT_DEPS)
 	$(MKDIR_P) $(@D)
@@ -91,6 +92,12 @@ $(O)/tests/test_Semver: $(O)/tests/test_Semver.o $(O)/TermColor.o
 
 $(O)/tests/test_VersionReq: $(O)/tests/test_VersionReq.o $(O)/TermColor.o \
   $(O)/Semver.o
+	$(CXX) $(CXXFLAGS) $^ $(LIBS) $(LDFLAGS) -o $@
+
+$(O)/tests/test_Manifest: $(O)/tests/test_Manifest.o $(O)/TermColor.o \
+  $(O)/Semver.o $(O)/VersionReq.o $(O)/Algos.o $(O)/Git2/Repository.o \
+  $(O)/Git2/Global.o $(O)/Git2/Oid.o $(O)/Git2/Config.o $(O)/Git2/Exception.o \
+  $(O)/Git2/Object.o
 	$(CXX) $(CXXFLAGS) $^ $(LIBS) $(LDFLAGS) -o $@
 
 


### PR DESCRIPTION
fixes https://github.com/poac-dev/poac/issues/921