### PR TITLE
workaround for libgit2 1.8 change (again)

### DIFF
--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -2,9 +2,12 @@
 
 #include "../Rustify.hpp"
 
-#include <git2/deprecated.h>
 #include <git2/errors.h>
 #include <git2/version.h>
+
+#if (LIBGIT2_VER_MAJOR >= 1) && (LIBGIT2_VER_MINOR >= 8)
+#  include <git2/sys/errors.h>
+#endif
 
 namespace git2 {
 
@@ -26,7 +29,7 @@ Exception::Exception() {
   if (const git_error* error = git_error_last(); error != nullptr) {
     this->msg += error->message;
     this->cat = static_cast<git_error_t>(error->klass);
-    giterr_clear();
+    git_error_clear();
   }
 }
 


### PR DESCRIPTION
As `git_error_*`s are already declared in `git2` namespace for older versions of libgit2, it's more favorable to use those identifiers than now deprecated ones, I suppose.

Another approach might be to use `git2::git_error_*`s always and make them wrap all changes (like below).
```cpp
namespace git2 {

void
git_error_clear() {
#if ((LIBGIT2_VER_MAJOR < 1) && (LIBGIT2_VER_MINOR < 28)) || ((LIBGIT2_VER_MAJOR >= 1) && (LIBGIT2_VER_MINOR >= 8))
  return ::giterr_clear();
#else
  return ::git_error_clear();
#endif
}

}
```