### PR TITLE
allow '-jn' style option

### DIFF
--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -66,6 +66,10 @@ buildMain(const std::span<const StringRef> args) {
         return Subcmd::missingArgumentForOpt(*itr);
       }
       setParallelism(std::stoul((++itr)->data()));
+    } else if (itr->starts_with("-j")) {
+      setParallelism(std::stoul(itr->substr(2).data()));
+    } else if (itr->starts_with("--jobs=")) {
+      setParallelism(std::stoul(itr->substr(7).data()));
     } else {
       return BUILD_CMD.noSuchArg(*itr);
     }


### PR DESCRIPTION
allowing option like `poac build -j8`

should we consider `poac build -rj8` as `poac build --release --jobs 8`?
