### PR TITLE
Drop libgit2 >=1.9 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PROJECT := $(O)/poac
 VERSION := $(shell grep -m1 version poac.toml | cut -f 2 -d'"')
 MKDIR_P := @mkdir -p
 
-LIBGIT2_VERREQ := libgit2 >= 1.1.0, libgit2 < 2.0.0
+LIBGIT2_VERREQ := libgit2 >= 1.1.0, libgit2 < 1.9.0
 LIBCURL_VERREQ := libcurl >= 7.79.1, libcurl < 9.0.0
 NLOHMANN_JSON_VERREQ := nlohmann_json >= 3.10.5, nlohmann_json < 4.0.0
 TBB_VERREQ := tbb >= 2021.5.0, tbb < 2022.0.0

--- a/poac.toml
+++ b/poac.toml
@@ -14,7 +14,7 @@ version = "0.9.3"
 "ToruNiina/toml11" = {git = "https://github.com/ToruNiina/toml11.git", tag = "v4.0.3"}
 fmt = {version = ">=8.1.1 && <11", system = true}
 libcurl = {version = ">=7.79.1 && <9", system = true}
-libgit2 = {version = "1.1.0", system = true}
+libgit2 = {version = ">=1.1.0 && <1.9", system = true}
 nlohmann_json = {version = "3.10.5", system = true}
 tbb = {version = "2021.5.0", system = true}
 


### PR DESCRIPTION
Related to: https://github.com/poac-dev/poac/pull/920, https://github.com/poac-dev/poac/issues/930

This is because they don't follow SemVer.