### PR TITLE
Allow usage of fmt 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LIBGIT2_VERREQ := libgit2 >= 1.1.0, libgit2 < 1.9.0
 LIBCURL_VERREQ := libcurl >= 7.79.1, libcurl < 9.0.0
 NLOHMANN_JSON_VERREQ := nlohmann_json >= 3.10.5, nlohmann_json < 4.0.0
 TBB_VERREQ := tbb >= 2021.5.0, tbb < 2022.0.0
-FMT_VERREQ := fmt >= 8.1.1, fmt < 11.0.0
+FMT_VERREQ := fmt >= 8.1.1, fmt < 12.0.0
 
 DEFINES := -DPOAC_POAC_PKG_VERSION='"$(VERSION)"' \
   -DPOAC_POAC_COMMIT_HASH='"$(COMMIT_HASH)"' \

--- a/poac.toml
+++ b/poac.toml
@@ -12,7 +12,7 @@ version = "0.10.0"
 
 [dependencies]
 toml11 = {git = "https://github.com/ToruNiina/toml11.git", tag = "v4.2.0"}
-fmt = {version = ">=8.1.1 && <11", system = true}
+fmt = {version = ">=8.1.1 && <12", system = true}
 libcurl = {version = ">=7.79.1 && <9", system = true}
 libgit2 = {version = ">=1.1.0 && <1.9", system = true}
 nlohmann_json = {version = "3.10.5", system = true}


### PR DESCRIPTION
Running `make && make test` succeeds with fmt 11.0.2.
