### PR TITLE
return

### DIFF
--- a/src/Cmd/New.cc
+++ b/src/Cmd/New.cc
@@ -32,6 +32,7 @@ static constexpr std::string_view MAIN_CC =
     "#include <iostream>\n\n"
     "int main() {\n"
     "  std::cout << \"Hello, world!\" << std::endl;\n"
+    "  return 0;\n"
     "}\n";
 
 static std::string


### PR DESCRIPTION
when generating a new project, `main.cc` will include a `return 0;` at the end of the `int main()` function

I think it's generally good practice to do so
