### PR TITLE
Use execve instead of std::system

### DIFF
--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -1,35 +1,27 @@
 #pragma once
 
+#include <cstdio>
 #include <iostream>
 #include <string>
-#include <cstring>
 
 class Command
 {
 private:
-    char* buf;
-    int len;
+    std::string buf;
 public:
-    Command(const char *arg) {
-        len = 0;
-        buf = (char *) malloc(sizeof(char) * strlen(arg));
-        if (buf == NULL) {
-            throw std::runtime_error("unable to allocate memory");
-        }
-        len += snprintf(buf+len, 3, "%s", arg);
+    Command(std::string arg) {
+        buf.append(arg);
     }
-    Command arg(const char *arg) {
-        buf = (char *) realloc(buf, strlen(buf)+strlen(arg));
-        if (buf == NULL) {
-            throw std::runtime_error("unable to allocate memory");
-        }
-        len += snprintf(buf+len, strlen(buf)+strlen(arg), " %s", arg);
+    ~Command() {
+    }
+    Command arg(std::string arg) {
+        buf.append(" ");
+        buf.append(arg);
         return *this;
     }
     Command output() {
-        fprintf(stdout, "%s\n", buf);
-        system(buf);
-        free(buf);
+        std::cout << buf << std::endl;
+        system(buf.data());
         return *this;
     }
 };

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <cstring>
+
+class Command
+{
+private:
+    char* buf;
+    int len;
+public:
+    Command(const char *arg) {
+        len = 0;
+        buf = (char *) malloc(sizeof(char) * strlen(arg));
+        if (buf == NULL) {
+            throw std::runtime_error("unable to allocate memory");
+        }
+        len += snprintf(buf+len, 3, "%s", arg);
+    }
+    Command arg(const char *arg) {
+        buf = (char *) realloc(buf, strlen(buf)+strlen(arg));
+        if (buf == NULL) {
+            throw std::runtime_error("unable to allocate memory");
+        }
+        len += snprintf(buf+len, strlen(buf)+strlen(arg), " %s", arg);
+        return *this;
+    }
+    Command output() {
+        fprintf(stdout, "%s\n", buf);
+        system(buf);
+        free(buf);
+        return *this;
+    }
+};


### PR DESCRIPTION
Currently, this pull request creates a class called `Command` that runs the command as input.

An example: `Command("cd").arg("poac").output()`

Closes #970