### PR TITLE
Keep going when poac tidy -fix

### DIFF
--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -102,6 +102,10 @@ tidyMain(const std::span<const std::string_view> args) {
   makeCmd.addArg(outDir.string());
   makeCmd.addArg(tidyFlags);
   makeCmd.addArg("tidy");
+  if (fix) {
+    // Keep going to apply fixes to as many files as possible.
+    makeCmd.addArg("--keep-going");
+  }
 
   logger::info("Running", "clang-tidy");
   return tidyImpl(makeCmd);


### PR DESCRIPTION
Prior to this patch, `poac tidy -fix` finishes every time it finds an error even if all are automatically fixed by `-fix`, so to apply auto fixes to all files, we needed to run the command many times. This patch resolves this problem.