### PR TITLE
clang-tidy: prefix member variables by m

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,14 +31,17 @@ CheckOptions:
     value: camelBack
   - key: readability-identifier-naming.NamespaceCase
     value: camelBack
-  - key: readability-identifier-naming.MemberCase
-    value: camelBack
   - key: readability-identifier-naming.MethodCase
     value: camelBack
   - key: readability-identifier-naming.ParameterCase
     value: camelBack
   - key: readability-identifier-naming.VariableCase
     value: camelBack
+  # mCamelCase is essentially camelBack but clang-tidy doesn't understand it
+  - key: readability-identifier-naming.MemberPrefix
+    value: m
+  - key: readability-identifier-naming.MemberCase
+    value: CamelCase
 
   - key: readability-identifier-naming.GlobalConstantCase
     value: UPPER_CASE

--- a/src/BuildConfig.hpp
+++ b/src/BuildConfig.hpp
@@ -31,38 +31,38 @@ enum class VarType : uint8_t {
 };
 
 struct Variable {
-  std::string value;
-  VarType type = VarType::Simple;
+  std::string mValue;
+  VarType mType = VarType::Simple;
 };
 
 struct Target {
-  std::vector<std::string> commands;
-  std::optional<std::string> sourceFile;
-  std::unordered_set<std::string> remDeps;
+  std::vector<std::string> mCommands;
+  std::optional<std::string> mSourceFile;
+  std::unordered_set<std::string> mRemDeps;
 };
 
 struct BuildConfig {
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
-  fs::path outBasePath;
+  fs::path mOutBasePath;
 
 private:
-  std::string packageName;
-  fs::path buildOutPath;
-  fs::path unittestOutPath;
-  bool isDebug;
+  std::string mPackageName;
+  fs::path mBuildOutPath;
+  fs::path mUnittestOutPath;
+  bool mIsDebug{};
 
-  std::unordered_map<std::string, Variable> variables;
-  std::unordered_map<std::string, std::vector<std::string>> varDeps;
-  std::unordered_map<std::string, Target> targets;
-  std::unordered_map<std::string, std::vector<std::string>> targetDeps;
-  std::optional<std::unordered_set<std::string>> phony;
-  std::optional<std::unordered_set<std::string>> all;
+  std::unordered_map<std::string, Variable> mVariables;
+  std::unordered_map<std::string, std::vector<std::string>> mVarDeps;
+  std::unordered_map<std::string, Target> mTargets;
+  std::unordered_map<std::string, std::vector<std::string>> mTargetDeps;
+  std::optional<std::unordered_set<std::string>> mPhony;
+  std::optional<std::unordered_set<std::string>> mAll;
 
-  std::string cxx;
-  std::vector<std::string> cxxflags;
-  std::vector<std::string> defines;
-  std::vector<std::string> includes = { "-I../../include" };
-  std::vector<std::string> libs;
+  std::string mCxx;
+  std::vector<std::string> mCxxflags;
+  std::vector<std::string> mDefines;
+  std::vector<std::string> mIncludes = { "-I../../include" };
+  std::vector<std::string> mLibs;
 
 public:
   explicit BuildConfig(const std::string& packageName, bool isDebug = true);
@@ -71,23 +71,23 @@ public:
       const std::string& name, const Variable& value,
       const std::unordered_set<std::string>& dependsOn = {}
   ) {
-    variables[name] = value;
+    mVariables[name] = value;
     for (const std::string& dep : dependsOn) {
       // reverse dependency
-      varDeps[dep].push_back(name);
+      mVarDeps[dep].push_back(name);
     }
   }
   void defineSimpleVar(
       const std::string& name, const std::string& value,
       const std::unordered_set<std::string>& dependsOn = {}
   ) {
-    defineVar(name, { .value = value, .type = VarType::Simple }, dependsOn);
+    defineVar(name, { .mValue = value, .mType = VarType::Simple }, dependsOn);
   }
   void defineCondVar(
       const std::string& name, const std::string& value,
       const std::unordered_set<std::string>& dependsOn = {}
   ) {
-    defineVar(name, { .value = value, .type = VarType::Cond }, dependsOn);
+    defineVar(name, { .mValue = value, .mType = VarType::Cond }, dependsOn);
   }
 
   void defineTarget(
@@ -95,29 +95,29 @@ public:
       const std::unordered_set<std::string>& remDeps = {},
       const std::optional<std::string>& sourceFile = std::nullopt
   ) {
-    targets[name] = { .commands = commands,
-                      .sourceFile = sourceFile,
-                      .remDeps = remDeps };
+    mTargets[name] = { .mCommands = commands,
+                       .mSourceFile = sourceFile,
+                       .mRemDeps = remDeps };
 
     if (sourceFile.has_value()) {
-      targetDeps[sourceFile.value()].push_back(name);
+      mTargetDeps[sourceFile.value()].push_back(name);
     }
     for (const std::string& dep : remDeps) {
       // reverse dependency
-      targetDeps[dep].push_back(name);
+      mTargetDeps[dep].push_back(name);
     }
   }
 
   void addPhony(const std::string& target) {
-    if (!phony.has_value()) {
-      phony = { target };
+    if (!mPhony.has_value()) {
+      mPhony = { target };
     } else {
-      phony->insert(target);
+      mPhony->insert(target);
     }
   }
 
   void setAll(const std::unordered_set<std::string>& dependsOn) {
-    all = dependsOn;
+    mAll = dependsOn;
   }
 
   void emitVariable(std::ostream& os, const std::string& varName) const;

--- a/src/Cli.hpp
+++ b/src/Cli.hpp
@@ -25,8 +25,8 @@ template <typename Derived>
 class CliBase {
 protected:
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
-  std::string_view name;
-  std::string_view desc;
+  std::string_view mName;
+  std::string_view mDesc;
   // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
 
 public:
@@ -38,9 +38,9 @@ public:
   constexpr CliBase& operator=(CliBase&&) noexcept = default;
 
   constexpr explicit CliBase(const std::string_view name) noexcept
-      : name(name) {}
+      : mName(name) {}
   constexpr Derived& setDesc(const std::string_view desc) noexcept {
-    this->desc = desc;
+    mDesc = desc;
     return static_cast<Derived&>(*this);
   }
 };
@@ -49,17 +49,17 @@ template <typename Derived>
 class ShortAndHidden {
 protected:
   // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
-  std::string_view shortName;
-  bool isHidden = false;
+  std::string_view mShortName;
+  bool mIsHidden = false;
   // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
 
 public:
   constexpr Derived& setShort(const std::string_view shortName) noexcept {
-    this->shortName = shortName;
+    mShortName = shortName;
     return static_cast<Derived&>(*this);
   }
   constexpr Derived& setHidden(const bool isHidden) noexcept {
-    this->isHidden = isHidden;
+    mIsHidden = isHidden;
     return static_cast<Derived&>(*this);
   }
 };
@@ -68,9 +68,9 @@ class Opt : public CliBase<Opt>, public ShortAndHidden<Opt> {
   friend class Subcmd;
   friend class Cli;
 
-  std::string_view placeholder;
-  std::string_view defaultVal;
-  bool isGlobal = false;
+  std::string_view mPlaceholder;
+  std::string_view mDefaultVal;
+  bool mIsGlobal = false;
 
 public:
   using CliBase::CliBase;
@@ -86,15 +86,15 @@ public:
   ) noexcept;
 
   constexpr Opt& setPlaceholder(const std::string_view placeholder) noexcept {
-    this->placeholder = placeholder;
+    mPlaceholder = placeholder;
     return *this;
   }
   constexpr Opt& setDefault(const std::string_view defaultVal) noexcept {
-    this->defaultVal = defaultVal;
+    mDefaultVal = defaultVal;
     return *this;
   }
   constexpr Opt& setGlobal(const bool isGlobal) noexcept {
-    this->isGlobal = isGlobal;
+    mIsGlobal = isGlobal;
     return *this;
   }
 
@@ -106,7 +106,7 @@ private:
     // lng.size() = ?
     // ` `.size() = 1
     // placeholder.size() = ?
-    return 3 + maxShortSize + name.size() + placeholder.size();
+    return 3 + maxShortSize + mName.size() + mPlaceholder.size();
   }
 
   void print(size_t maxShortSize, size_t maxOffset) const noexcept;
@@ -115,25 +115,25 @@ private:
 class Arg : public CliBase<Arg> {
   friend class Subcmd;
 
-  bool required = true;
-  bool variadic = false;
+  bool mRequired = true;
+  bool mVariadic = false;
 
 public:
   using CliBase::CliBase;
 
   constexpr Arg& setRequired(const bool required) noexcept {
-    this->required = required;
+    mRequired = required;
     return *this;
   }
   constexpr Arg& setVariadic(const bool variadic) noexcept {
-    this->variadic = variadic;
+    mVariadic = variadic;
     return *this;
   }
 
 private:
   /// Size of left side of the help message.
   constexpr size_t leftSize() const noexcept {
-    return name.size();
+    return mName.size();
   }
 
   std::string getLeft() const noexcept;
@@ -143,17 +143,17 @@ private:
 class Subcmd : public CliBase<Subcmd>, public ShortAndHidden<Subcmd> {
   friend class Cli;
 
-  std::string_view cmdName;
-  std::optional<std::vector<Opt>> globalOpts = std::nullopt;
-  std::vector<Opt> localOpts;
-  Arg arg;
-  std::function<int(std::span<const std::string_view>)> mainFn;
+  std::string_view mCmdName;
+  std::optional<std::vector<Opt>> mGlobalOpts = std::nullopt;
+  std::vector<Opt> mLocalOpts;
+  Arg mArg;
+  std::function<int(std::span<const std::string_view>)> mMainFn;
 
 public:
   using CliBase::CliBase;
 
   constexpr Subcmd& setArg(Arg arg) noexcept {
-    this->arg = arg;
+    mArg = arg;
     return *this;
   }
 
@@ -165,10 +165,10 @@ public:
 
 private:
   constexpr bool hasShort() const noexcept {
-    return !shortName.empty();
+    return !mShortName.empty();
   }
   constexpr Subcmd& setCmdName(std::string_view cmdName) noexcept {
-    this->cmdName = cmdName;
+    mCmdName = cmdName;
     return *this;
   }
 
@@ -184,9 +184,9 @@ private:
 };
 
 class Cli : public CliBase<Cli> {
-  std::unordered_map<std::string_view, Subcmd> subcmds;
-  std::vector<Opt> globalOpts;
-  std::vector<Opt> localOpts;
+  std::unordered_map<std::string_view, Subcmd> mSubcmds;
+  std::vector<Opt> mGlobalOpts;
+  std::vector<Opt> mLocalOpts;
 
 public:
   using CliBase::CliBase;

--- a/src/Cmd/Build.cc
+++ b/src/Cmd/Build.cc
@@ -37,11 +37,11 @@ buildImpl(std::string& outDir, const bool isDebug) {
   const auto start = std::chrono::steady_clock::now();
 
   const BuildConfig config = emitMakefile(isDebug, /*includeDevDeps=*/false);
-  outDir = config.outBasePath;
+  outDir = config.mOutBasePath;
 
   const std::string& packageName = getPackageName();
   const Command makeCmd = getMakeCommand().addArg("-C").addArg(outDir).addArg(
-      (config.outBasePath / packageName).string()
+      (config.mOutBasePath / packageName).string()
   );
   Command checkUpToDateCmd = makeCmd;
   checkUpToDateCmd.addArg("--question");
@@ -64,12 +64,12 @@ buildImpl(std::string& outDir, const bool isDebug) {
     const Profile& profile = isDebug ? getDevProfile() : getReleaseProfile();
 
     std::vector<std::string_view> profiles;
-    if (profile.optLevel.value() == 0) {
+    if (profile.mOptLevel.value() == 0) {
       profiles.emplace_back("unoptimized");
     } else {
       profiles.emplace_back("optimized");
     }
-    if (profile.debug.value()) {
+    if (profile.mDebug.value()) {
       profiles.emplace_back("debuginfo");
     }
 

--- a/src/Cmd/Lint.cc
+++ b/src/Cmd/Lint.cc
@@ -23,7 +23,7 @@ const Subcmd LINT_CMD = Subcmd{ "lint" }
                             .setMainFn(lintMain);
 
 struct LintArgs {
-  std::vector<std::string> excludes;
+  std::vector<std::string> mExcludes;
 };
 
 static int
@@ -68,7 +68,7 @@ lintMain(const std::span<const std::string_view> args) {
         return Subcmd::missingArgumentForOpt(*itr);
       }
 
-      lintArgs.excludes.push_back("--exclude=" + std::string(*++itr));
+      lintArgs.mExcludes.push_back("--exclude=" + std::string(*++itr));
     } else {
       return LINT_CMD.noSuchArg(*itr);
     }
@@ -82,7 +82,7 @@ lintMain(const std::span<const std::string_view> args) {
     return EXIT_FAILURE;
   }
 
-  std::vector<std::string> cpplintArgs = lintArgs.excludes;
+  std::vector<std::string> cpplintArgs = lintArgs.mExcludes;
   const std::string_view packageName = getPackageName();
   if (fs::exists("CPPLINT.cfg")) {
     logger::debug("Using CPPLINT.cfg for lint ...");

--- a/src/Cmd/Search.cc
+++ b/src/Cmd/Search.cc
@@ -30,9 +30,9 @@ const Subcmd SEARCH_CMD =
         .setMainFn(searchMain);
 
 struct SearchArgs {
-  std::string name;
-  size_t perPage = 10;
-  size_t page = 1;
+  std::string mName;
+  size_t mPerPage = 10;
+  size_t mPage = 1;
 };
 
 static size_t
@@ -47,9 +47,9 @@ searchPackages(const SearchArgs& args) {
   req["query"] =
 #include "../GraphQL/SearchPackages.gql"
       ;
-  req["variables"]["name"] = "%" + args.name + "%";
-  req["variables"]["limit"] = args.perPage;
-  req["variables"]["offset"] = (args.page - 1) * args.perPage;
+  req["variables"]["name"] = "%" + args.mName + "%";
+  req["variables"]["limit"] = args.mPerPage;
+  req["variables"]["offset"] = (args.mPage - 1) * args.mPerPage;
 
   const std::string reqStr = req.dump();
   std::string resStr;
@@ -105,26 +105,26 @@ searchMain(const std::span<const std::string_view> args) {
       }
     } else if (*itr == "--per-page") {
       if (itr + 1 < args.end()) {
-        searchArgs.perPage = std::stoul(std::string(*++itr));
+        searchArgs.mPerPage = std::stoul(std::string(*++itr));
       } else {
         logger::error("missing argument for `--per-page`");
         return EXIT_FAILURE;
       }
     } else if (*itr == "--page") {
       if (itr + 1 < args.end()) {
-        searchArgs.page = std::stoul(std::string(*++itr));
+        searchArgs.mPage = std::stoul(std::string(*++itr));
       } else {
         logger::error("missing argument for `--page`");
         return EXIT_FAILURE;
       }
-    } else if (searchArgs.name.empty()) {
-      searchArgs.name = *itr;
+    } else if (searchArgs.mName.empty()) {
+      searchArgs.mName = *itr;
     } else {
       return SEARCH_CMD.noSuchArg(*itr);
     }
   }
 
-  if (searchArgs.name.empty()) {
+  if (searchArgs.mName.empty()) {
     logger::error("missing package name");
     return EXIT_FAILURE;
   }

--- a/src/Cmd/Test.cc
+++ b/src/Cmd/Test.cc
@@ -75,9 +75,9 @@ testMain(const std::span<const std::string_view> args) {
 
   // Collect test targets from the generated Makefile.
   const std::string unittestTargetPrefix =
-      (config.outBasePath / "unittests").string() + '/';
+      (config.mOutBasePath / "unittests").string() + '/';
   std::vector<std::string> unittestTargets;
-  std::ifstream infile(config.outBasePath / "Makefile");
+  std::ifstream infile(config.mOutBasePath / "Makefile");
   std::string line;
   while (std::getline(infile, line)) {
     if (!line.starts_with(unittestTargetPrefix)) {
@@ -97,7 +97,7 @@ testMain(const std::span<const std::string_view> args) {
 
   const std::string& packageName = getPackageName();
   const Command baseMakeCmd =
-      getMakeCommand().addArg("-C").addArg(config.outBasePath.string());
+      getMakeCommand().addArg("-C").addArg(config.mOutBasePath.string());
 
   // Find not up-to-date test targets, emit compilation status once, and
   // compile them.

--- a/src/Cmd/Tidy.cc
+++ b/src/Cmd/Tidy.cc
@@ -87,19 +87,19 @@ tidyMain(const std::span<const std::string_view> args) {
 
   std::string tidyFlags = "POAC_TIDY_FLAGS=";
   if (!isVerbose()) {
-    tidyFlags += "-quiet";
+    tidyFlags += "--quiet";
   }
   if (fs::exists(".clang-tidy")) {
     // clang-tidy will run within the poac-out/debug directory.
     tidyFlags += " --config-file=../../.clang-tidy";
   }
   if (fix) {
-    tidyFlags += " -fix";
+    tidyFlags += " --fix";
   }
 
   Command makeCmd(getMakeCommand());
   makeCmd.addArg("-C");
-  makeCmd.addArg(config.outBasePath.string());
+  makeCmd.addArg(config.mOutBasePath.string());
   makeCmd.addArg(tidyFlags);
   makeCmd.addArg("tidy");
   if (fix) {

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -10,19 +10,19 @@
 #include <vector>
 
 struct CommandOutput {
-  int exitCode;
-  std::string stdout;
-  std::string stderr;
+  int mExitCode;
+  std::string mStdout;
+  std::string mStderr;
 };
 
 class Child {
 private:
-  pid_t pid;
-  int stdoutfd;
-  int stderrfd;
+  pid_t mPid;
+  int mStdoutfd;
+  int mStderrfd;
 
   Child(pid_t pid, int stdoutfd, int stderrfd) noexcept
-      : pid(pid), stdoutfd(stdoutfd), stderrfd(stderrfd) {}
+      : mPid(pid), mStdoutfd(stdoutfd), mStderrfd(stderrfd) {}
 
   friend struct Command;
 
@@ -38,35 +38,35 @@ struct Command {
     Piped,
   };
 
-  std::string command;
-  std::vector<std::string> arguments;
-  std::filesystem::path workingDirectory;
-  IOConfig stdoutConfig = IOConfig::Inherit;
-  IOConfig stderrConfig = IOConfig::Inherit;
+  std::string mCommand;
+  std::vector<std::string> mArguments;
+  std::filesystem::path mWorkingDirectory;
+  IOConfig mStdoutConfig = IOConfig::Inherit;
+  IOConfig mStderrConfig = IOConfig::Inherit;
 
-  explicit Command(std::string_view cmd) : command(cmd) {}
+  explicit Command(std::string_view cmd) : mCommand(cmd) {}
   Command(std::string_view cmd, std::vector<std::string> args)
-      : command(cmd), arguments(std::move(args)) {}
+      : mCommand(cmd), mArguments(std::move(args)) {}
 
   Command& addArg(const std::string_view arg) {
-    arguments.emplace_back(arg);
+    mArguments.emplace_back(arg);
     return *this;
   }
   Command& addArgs(const std::vector<std::string>& args) {
-    arguments.insert(arguments.end(), args.begin(), args.end());
+    mArguments.insert(mArguments.end(), args.begin(), args.end());
     return *this;
   }
 
   Command& setStdoutConfig(IOConfig config) noexcept {
-    stdoutConfig = config;
+    mStdoutConfig = config;
     return *this;
   }
   Command& setStderrConfig(IOConfig config) noexcept {
-    stderrConfig = config;
+    mStderrConfig = config;
     return *this;
   }
   Command& setWorkingDirectory(const std::filesystem::path& dir) {
-    workingDirectory = dir;
+    mWorkingDirectory = dir;
     return *this;
   }
 

--- a/src/CurlVersion.cc
+++ b/src/CurlVersion.cc
@@ -6,10 +6,10 @@ namespace curl {
 
 std::ostream&
 operator<<(std::ostream& os, const Version& version) {
-  if (version.data) {
-    os << version.data->version << " (ssl: ";
-    if (version.data->ssl_version) {
-      os << version.data->ssl_version;
+  if (version.mData) {
+    os << version.mData->version << " (ssl: ";
+    if (version.mData->ssl_version) {
+      os << version.mData->ssl_version;
     } else {
       os << "none";
     }

--- a/src/CurlVersion.hpp
+++ b/src/CurlVersion.hpp
@@ -6,9 +6,9 @@
 namespace curl {
 
 struct Version {
-  curl_version_info_data* data;
+  curl_version_info_data* mData;
 
-  Version() : data(curl_version_info(CURLVERSION_NOW)) {}
+  Version() : mData(curl_version_info(CURLVERSION_NOW)) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const Version& version);

--- a/src/Git2/Commit.cc
+++ b/src/Git2/Commit.cc
@@ -10,18 +10,18 @@
 namespace git2 {
 
 Commit::~Commit() {
-  git_commit_free(this->raw);
+  git_commit_free(mRaw);
 }
 
 Commit&
 Commit::lookup(const Repository& repo, const Oid& oid) {
-  git2Throw(git_commit_lookup(&this->raw, repo.raw, oid.raw));
+  git2Throw(git_commit_lookup(&mRaw, repo.mRaw, oid.mRaw));
   return *this;
 }
 
 Time
 Commit::time() const {
-  return { git_commit_time(this->raw) };
+  return { git_commit_time(mRaw) };
 }
 
 } // namespace git2

--- a/src/Git2/Commit.hpp
+++ b/src/Git2/Commit.hpp
@@ -10,7 +10,7 @@
 namespace git2 {
 
 struct Commit : public GlobalState {
-  git_commit* raw = nullptr;
+  git_commit* mRaw = nullptr;
 
   Commit() = default;
   ~Commit();

--- a/src/Git2/Config.cc
+++ b/src/Git2/Config.cc
@@ -7,25 +7,25 @@
 namespace git2 {
 
 Config::Config() {
-  git2Throw(git_config_new(&this->raw));
+  git2Throw(git_config_new(&mRaw));
 }
 
-Config::Config(git_config* raw) : raw(raw) {}
+Config::Config(git_config* raw) : mRaw(raw) {}
 
 Config::~Config() {
-  git_config_free(this->raw);
+  git_config_free(mRaw);
 }
 
 Config&
 Config::openDefault() {
-  git2Throw(git_config_open_default(&this->raw));
+  git2Throw(git_config_open_default(&mRaw));
   return *this;
 }
 
 std::string
 Config::getString(const std::string& name) {
   git_buf ret = { nullptr, 0, 0 };
-  git2Throw(git_config_get_string_buf(&ret, this->raw, name.c_str()));
+  git2Throw(git_config_get_string_buf(&ret, mRaw, name.c_str()));
   return { ret.ptr, ret.size };
 }
 

--- a/src/Git2/Config.hpp
+++ b/src/Git2/Config.hpp
@@ -9,7 +9,7 @@ namespace git2 {
 
 struct Config : public GlobalState {
 private:
-  git_config* raw = nullptr;
+  git_config* mRaw = nullptr;
 
 public:
   Config();

--- a/src/Git2/Describe.cc
+++ b/src/Git2/Describe.cc
@@ -16,44 +16,44 @@ DescribeOptions::DescribeOptions() {
 #else
       git_describe_options_init(
 #endif
-          &this->raw, GIT_DESCRIBE_OPTIONS_VERSION
+          &mRaw, GIT_DESCRIBE_OPTIONS_VERSION
       )
   );
 }
 
 DescribeOptions&
 DescribeOptions::maxCandidatesTags(const unsigned int max) {
-  this->raw.max_candidates_tags = max;
+  mRaw.max_candidates_tags = max;
   return *this;
 }
 
 DescribeOptions&
 DescribeOptions::describeTags() {
-  this->raw.describe_strategy = GIT_DESCRIBE_TAGS;
+  mRaw.describe_strategy = GIT_DESCRIBE_TAGS;
   return *this;
 }
 
 DescribeOptions&
 DescribeOptions::describeAll() {
-  this->raw.describe_strategy = GIT_DESCRIBE_ALL;
+  mRaw.describe_strategy = GIT_DESCRIBE_ALL;
   return *this;
 }
 
 DescribeOptions&
 DescribeOptions::onlyFollowFirstParent(const bool follow) {
-  this->raw.only_follow_first_parent = follow;
+  mRaw.only_follow_first_parent = follow;
   return *this;
 }
 
 DescribeOptions&
 DescribeOptions::showCommitOidAsFallback(const bool show) {
-  this->raw.show_commit_oid_as_fallback = show;
+  mRaw.show_commit_oid_as_fallback = show;
   return *this;
 }
 
 DescribeOptions&
 DescribeOptions::pattern(const std::string_view pattern) {
-  this->raw.pattern = pattern.data();
+  mRaw.pattern = pattern.data();
   return *this;
 }
 
@@ -64,43 +64,43 @@ DescribeFormatOptions::DescribeFormatOptions() {
 #else
       git_describe_format_options_init(
 #endif
-          &this->raw, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION
+          &mRaw, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION
       )
   );
 }
 
 DescribeFormatOptions&
 DescribeFormatOptions::abbreviatedSize(const unsigned int size) {
-  this->raw.abbreviated_size = size;
+  mRaw.abbreviated_size = size;
   return *this;
 }
 
 DescribeFormatOptions&
 DescribeFormatOptions::alwaysUseLongFormat(const bool longF) {
-  this->raw.always_use_long_format = longF;
+  mRaw.always_use_long_format = longF;
   return *this;
 }
 
 DescribeFormatOptions&
 DescribeFormatOptions::dirtySuffix(const std::string_view suffix) {
-  this->raw.dirty_suffix = suffix.data();
+  mRaw.dirty_suffix = suffix.data();
   return *this;
 }
 
 Describe::~Describe() {
-  git_describe_result_free(this->raw);
+  git_describe_result_free(mRaw);
 }
 
 Describe&
 Describe::workdir(const Repository& repo, DescribeOptions& opts) {
-  git2Throw(git_describe_workdir(&this->raw, repo.raw, &opts.raw));
+  git2Throw(git_describe_workdir(&mRaw, repo.mRaw, &opts.mRaw));
   return *this;
 }
 
 std::string
 Describe::format(const DescribeFormatOptions& opts) const {
   git_buf ret = { nullptr, 0, 0 };
-  git2Throw(git_describe_format(&ret, this->raw, &opts.raw));
+  git2Throw(git_describe_format(&ret, mRaw, &opts.mRaw));
   return { ret.ptr, ret.size };
 }
 

--- a/src/Git2/Describe.hpp
+++ b/src/Git2/Describe.hpp
@@ -10,7 +10,7 @@
 namespace git2 {
 
 struct DescribeOptions : public GlobalState {
-  git_describe_options raw{};
+  git_describe_options mRaw{};
 
   DescribeOptions();
   ~DescribeOptions() noexcept = default;
@@ -45,7 +45,7 @@ struct DescribeOptions : public GlobalState {
 };
 
 struct DescribeFormatOptions : public GlobalState {
-  git_describe_format_options raw{};
+  git_describe_format_options mRaw{};
 
   DescribeFormatOptions();
   ~DescribeFormatOptions() = default;
@@ -71,7 +71,7 @@ struct DescribeFormatOptions : public GlobalState {
 };
 
 struct Describe : public GlobalState {
-  git_describe_result* raw = nullptr;
+  git_describe_result* mRaw = nullptr;
 
   Describe() = default;
   ~Describe();

--- a/src/Git2/Exception.cc
+++ b/src/Git2/Exception.cc
@@ -27,19 +27,19 @@ git_error_clear() {
 
 Exception::Exception() {
   if (const git_error* error = git_error_last(); error != nullptr) {
-    this->msg += error->message;
-    this->cat = static_cast<git_error_t>(error->klass);
+    mMsg += error->message;
+    mCat = static_cast<git_error_t>(error->klass);
     git_error_clear();
   }
 }
 
 const char*
 Exception::what() const noexcept {
-  return this->msg.c_str();
+  return mMsg.c_str();
 }
 git_error_t
 Exception::category() const noexcept {
-  return this->cat;
+  return mCat;
 }
 
 int

--- a/src/Git2/Exception.hpp
+++ b/src/Git2/Exception.hpp
@@ -64,8 +64,8 @@ struct Exception final : public std::exception {
   Exception& operator=(Exception&&) noexcept = default;
 
 private:
-  std::string msg = "git2-cpp: ";
-  git_error_t cat{ GIT_ERROR_NONE };
+  std::string mMsg = "git2-cpp: ";
+  git_error_t mCat{ GIT_ERROR_NONE };
 };
 
 int git2Throw(int ret);

--- a/src/Git2/Object.cc
+++ b/src/Git2/Object.cc
@@ -7,14 +7,14 @@
 namespace git2 {
 
 Object::~Object() {
-  git_object_free(this->raw);
+  git_object_free(mRaw);
 }
 
-Object::Object(git_object* obj) : raw(obj) {}
+Object::Object(git_object* obj) : mRaw(obj) {}
 
 Oid
 Object::id() const {
-  return Oid(git_object_id(this->raw));
+  return Oid(git_object_id(mRaw));
 }
 
 } // namespace git2

--- a/src/Git2/Object.hpp
+++ b/src/Git2/Object.hpp
@@ -8,7 +8,7 @@
 namespace git2 {
 
 struct Object : public GlobalState {
-  git_object* raw = nullptr;
+  git_object* mRaw = nullptr;
 
   Object() = default;
   ~Object();

--- a/src/Git2/Oid.cc
+++ b/src/Git2/Oid.cc
@@ -10,23 +10,23 @@
 
 namespace git2 {
 
-Oid::Oid(git_oid oid) : oid(oid), raw(&this->oid) {}
+Oid::Oid(git_oid oid) : mOid(oid), mRaw(&mOid) {}
 
-Oid::Oid(git_oid* oid) : oid(*oid), raw(oid) {}
+Oid::Oid(git_oid* oid) : mOid(*oid), mRaw(oid) {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
 Oid::Oid(const git_oid* oid) : Oid(const_cast<git_oid*>(oid)) {}
 
 Oid::Oid(const std::string_view str) {
-  git2Throw(git_oid_fromstrn(raw, str.data(), str.size()));
+  git2Throw(git_oid_fromstrn(mRaw, str.data(), str.size()));
 }
 
 bool
 Oid::isZero() const {
 #if (LIBGIT2_VER_MAJOR < 1) && (LIBGIT2_VER_MINOR < 99)
-  return git_oid_iszero(raw) == 1;
+  return git_oid_iszero(mRaw) == 1;
 #else
-  return git_oid_is_zero(raw) == 1;
+  return git_oid_is_zero(mRaw) == 1;
 #endif
 }
 
@@ -37,18 +37,18 @@ Oid::isZero() const {
 std::string
 Oid::toString() const {
   std::string buf(GIT_OID_MAX_HEXSIZE, '\0');
-  git_oid_tostr(buf.data(), buf.size() + 1, raw);
+  git_oid_tostr(buf.data(), buf.size() + 1, mRaw);
   return buf;
 }
 
 std::ostream&
 operator<<(std::ostream& os, const Oid& oid) {
-  return (os << git_oid_tostr_s(oid.raw));
+  return (os << git_oid_tostr_s(oid.mRaw));
 }
 
 inline bool
 operator==(const Oid& lhs, const Oid& rhs) {
-  return git_oid_equal(lhs.raw, rhs.raw) != 0;
+  return git_oid_equal(lhs.mRaw, rhs.mRaw) != 0;
 }
 
 } // end namespace git2

--- a/src/Git2/Oid.hpp
+++ b/src/Git2/Oid.hpp
@@ -14,8 +14,8 @@ inline constexpr size_t SHORT_HASH_LEN = 8;
 
 struct Oid : public GlobalState {
   // TODO: ideally, use one of the following:
-  git_oid oid{};
-  git_oid* raw = nullptr;
+  git_oid mOid{};
+  git_oid* mRaw = nullptr;
 
   explicit Oid(git_oid oid);
 

--- a/src/Git2/Repository.cc
+++ b/src/Git2/Repository.cc
@@ -12,35 +12,35 @@
 namespace git2 {
 
 Repository::~Repository() {
-  git_repository_free(this->raw);
+  git_repository_free(mRaw);
 }
 
 Repository&
 Repository::open(const std::string& path) {
-  git2Throw(git_repository_open(&this->raw, path.c_str()));
+  git2Throw(git_repository_open(&mRaw, path.c_str()));
   return *this;
 }
 Repository&
 Repository::openBare(const std::string& path) {
-  git2Throw(git_repository_open_bare(&this->raw, path.c_str()));
+  git2Throw(git_repository_open_bare(&mRaw, path.c_str()));
   return *this;
 }
 
 Repository&
 Repository::init(const std::string& path) {
-  git2Throw(git_repository_init(&this->raw, path.c_str(), false));
+  git2Throw(git_repository_init(&mRaw, path.c_str(), false));
   return *this;
 }
 Repository&
 Repository::initBare(const std::string& path) {
-  git2Throw(git_repository_init(&this->raw, path.c_str(), true));
+  git2Throw(git_repository_init(&mRaw, path.c_str(), true));
   return *this;
 }
 
 bool
 Repository::isIgnored(const std::string& path) const {
   int ignored = 0;
-  git2Throw(git_ignore_path_is_ignored(&ignored, this->raw, path.c_str()));
+  git2Throw(git_ignore_path_is_ignored(&ignored, mRaw, path.c_str()));
   return static_cast<bool>(ignored);
 }
 
@@ -49,20 +49,20 @@ Repository::clone(
     const std::string& url, const std::string& path,
     const git_clone_options* opts
 ) {
-  git2Throw(git_clone(&this->raw, url.c_str(), path.c_str(), opts));
+  git2Throw(git_clone(&mRaw, url.c_str(), path.c_str(), opts));
   return *this;
 }
 
 Object
 Repository::revparseSingle(const std::string& spec) const {
   git_object* obj = nullptr;
-  git2Throw(git_revparse_single(&obj, this->raw, spec.c_str()));
+  git2Throw(git_revparse_single(&obj, mRaw, spec.c_str()));
   return git2::Object(obj);
 }
 
 Repository&
 Repository::setHeadDetached(const Oid& oid) {
-  git2Throw(git_repository_set_head_detached(this->raw, oid.raw));
+  git2Throw(git_repository_set_head_detached(mRaw, oid.mRaw));
   return *this;
 }
 
@@ -71,21 +71,21 @@ Repository::checkoutHead(bool force) {
   git_checkout_options opts;
   git2Throw(git_checkout_options_init(&opts, GIT_CHECKOUT_OPTIONS_VERSION));
   opts.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
-  git2Throw(git_checkout_head(this->raw, &opts));
+  git2Throw(git_checkout_head(mRaw, &opts));
   return *this;
 }
 
 Oid
 Repository::refNameToId(const std::string& refname) const {
   git_oid oid;
-  git2Throw(git_reference_name_to_id(&oid, this->raw, refname.c_str()));
+  git2Throw(git_reference_name_to_id(&oid, mRaw, refname.c_str()));
   return Oid(oid);
 }
 
 git2::Config
 Repository::config() const {
   git_config* cfg = nullptr;
-  git2Throw(git_repository_config(&cfg, this->raw));
+  git2Throw(git_repository_config(&cfg, mRaw));
   return git2::Config(cfg);
 }
 

--- a/src/Git2/Repository.hpp
+++ b/src/Git2/Repository.hpp
@@ -12,7 +12,7 @@
 namespace git2 {
 
 struct Repository : public GlobalState {
-  git_repository* raw = nullptr;
+  git_repository* mRaw = nullptr;
 
   Repository() = default;
   ~Repository();

--- a/src/Git2/Revparse.cc
+++ b/src/Git2/Revparse.cc
@@ -6,17 +6,17 @@ namespace git2 {
 
 git_object*
 Revspec::from() const noexcept {
-  return this->fromObj;
+  return mFromObj;
 }
 
 git_object*
 Revspec::to() const noexcept {
-  return this->toObj;
+  return mToObj;
 }
 
 unsigned int
 Revspec::mode() const noexcept {
-  return this->modeVal;
+  return mModeVal;
 }
 
 } // end namespace git2

--- a/src/Git2/Revparse.hpp
+++ b/src/Git2/Revparse.hpp
@@ -8,14 +8,14 @@ namespace git2 {
 
 struct Revspec : public GlobalState {
 private:
-  git_object* fromObj = nullptr;
-  git_object* toObj = nullptr;
-  unsigned int modeVal; // git_revparse_mode_t
+  git_object* mFromObj = nullptr;
+  git_object* mToObj = nullptr;
+  unsigned int mModeVal; // git_revparse_mode_t
 
 public:
   /// Assembles a new revspec from the from/to components.
   Revspec(git_object* from, git_object* toO, unsigned int mode)
-      : fromObj(from), toObj(toO), modeVal(mode) {}
+      : mFromObj(from), mToObj(toO), mModeVal(mode) {}
   Revspec() = delete;
   ~Revspec() = default;
 

--- a/src/Git2/Revwalk.cc
+++ b/src/Git2/Revwalk.cc
@@ -9,81 +9,81 @@
 namespace git2 {
 
 Revwalk::Revwalk(const Repository& repo) {
-  git2Throw(git_revwalk_new(&this->raw, repo.raw));
+  git2Throw(git_revwalk_new(&mRaw, repo.mRaw));
 }
 Revwalk::~Revwalk() noexcept {
-  git_revwalk_free(this->raw);
+  git_revwalk_free(mRaw);
 }
 
 Revwalk&
 Revwalk::reset() {
-  git_revwalk_reset(this->raw);
+  git_revwalk_reset(mRaw);
   return *this;
 }
 
 Revwalk&
 Revwalk::setSorting(unsigned int sortMode) {
-  git_revwalk_sorting(this->raw, sortMode);
+  git_revwalk_sorting(mRaw, sortMode);
   return *this;
 }
 
 Revwalk&
 Revwalk::simplifyFirstParent() {
-  git_revwalk_simplify_first_parent(this->raw);
+  git_revwalk_simplify_first_parent(mRaw);
   return *this;
 }
 
 Revwalk&
 Revwalk::push(const Oid& oid) {
-  git2Throw(git_revwalk_push(this->raw, oid.raw));
+  git2Throw(git_revwalk_push(mRaw, oid.mRaw));
   return *this;
 }
 
 Revwalk&
 Revwalk::pushHead() {
-  git2Throw(git_revwalk_push_head(this->raw));
+  git2Throw(git_revwalk_push_head(mRaw));
   return *this;
 }
 
 Revwalk&
 Revwalk::pushGlob(const std::string& glob) {
-  git2Throw(git_revwalk_push_glob(this->raw, glob.c_str()));
+  git2Throw(git_revwalk_push_glob(mRaw, glob.c_str()));
   return *this;
 }
 
 Revwalk&
 Revwalk::pushRange(const std::string& range) {
-  git2Throw(git_revwalk_push_range(this->raw, range.c_str()));
+  git2Throw(git_revwalk_push_range(mRaw, range.c_str()));
   return *this;
 }
 
 Revwalk&
 Revwalk::pushRef(const std::string& reference) {
-  git2Throw(git_revwalk_push_ref(this->raw, reference.c_str()));
+  git2Throw(git_revwalk_push_ref(mRaw, reference.c_str()));
   return *this;
 }
 
 Revwalk&
 Revwalk::hide(const Oid& oid) {
-  git2Throw(git_revwalk_hide(this->raw, oid.raw));
+  git2Throw(git_revwalk_hide(mRaw, oid.mRaw));
   return *this;
 }
 
 Revwalk&
 Revwalk::hideHead() {
-  git2Throw(git_revwalk_hide_head(this->raw));
+  git2Throw(git_revwalk_hide_head(mRaw));
   return *this;
 }
 
 Revwalk&
 Revwalk::hideGlob(const std::string& glob) {
-  git2Throw(git_revwalk_hide_glob(this->raw, glob.c_str()));
+  git2Throw(git_revwalk_hide_glob(mRaw, glob.c_str()));
   return *this;
 }
 
 Revwalk&
 Revwalk::hideRef(const std::string& reference) {
-  git2Throw(git_revwalk_hide_ref(this->raw, reference.c_str()));
+  git2Throw(git_revwalk_hide_ref(mRaw, reference.c_str()));
   return *this;
 }
 

--- a/src/Git2/Revwalk.hpp
+++ b/src/Git2/Revwalk.hpp
@@ -10,7 +10,7 @@
 namespace git2 {
 
 struct Revwalk : public GlobalState {
-  git_revwalk* raw = nullptr;
+  git_revwalk* mRaw = nullptr;
 
   Revwalk() = delete;
   explicit Revwalk(const Repository& repo);

--- a/src/Git2/Time.cc
+++ b/src/Git2/Time.cc
@@ -9,14 +9,14 @@ namespace git2 {
 
 std::string
 Time::toString() const {
-  const auto time2 = static_cast<std::time_t>(time);
-  std::tm* time3 = std::localtime(&time2);
+  const auto time = static_cast<std::time_t>(mTime);
+  std::tm* time2 = std::localtime(&time);
 
   constexpr size_t dateLen = 10; // YYYY-MM-DD
   std::string buffer(dateLen, '\0');
   if (std::strftime(
           buffer.data(), dateLen + 1, // null-terminator
-          "%Y-%m-%d", time3
+          "%Y-%m-%d", time2
       )
       == 0) {
     return {};

--- a/src/Git2/Time.hpp
+++ b/src/Git2/Time.hpp
@@ -8,7 +8,7 @@
 namespace git2 {
 
 struct Time {
-  git_time_t time;
+  git_time_t mTime;
 
   std::string toString() const;
 };

--- a/src/Git2/Version.cc
+++ b/src/Git2/Version.cc
@@ -4,34 +4,34 @@
 
 namespace git2 {
 
-Version::Version() : features(git2Throw(git_libgit2_features())) {
-  git2Throw(git_libgit2_version(&this->major, &this->minor, &this->rev));
+Version::Version() : mFeatures(git2Throw(git_libgit2_features())) {
+  git2Throw(git_libgit2_version(&mMajor, &mMinor, &mRev));
 }
 
 bool
 Version::hasThread() const noexcept {
-  return this->features & GIT_FEATURE_THREADS;
+  return mFeatures & GIT_FEATURE_THREADS;
 }
 
 bool
 Version::hasHttps() const noexcept {
-  return this->features & GIT_FEATURE_HTTPS;
+  return mFeatures & GIT_FEATURE_HTTPS;
 }
 
 bool
 Version::hasSsh() const noexcept {
-  return this->features & GIT_FEATURE_SSH;
+  return mFeatures & GIT_FEATURE_SSH;
 }
 
 bool
 Version::hasNsec() const noexcept {
-  return this->features & GIT_FEATURE_NSEC;
+  return mFeatures & GIT_FEATURE_NSEC;
 }
 
 std::ostream&
 operator<<(std::ostream& os, const Version& version) {
   const auto flagStr = [](const bool flag) { return flag ? "on" : "off"; };
-  return os << version.major << '.' << version.minor << '.' << version.rev
+  return os << version.mMajor << '.' << version.mMinor << '.' << version.mRev
             << " (threads: " << flagStr(version.hasThread()) << ", "
             << "https: " << flagStr(version.hasHttps()) << ", "
             << "ssh: " << flagStr(version.hasSsh()) << ", "

--- a/src/Git2/Version.hpp
+++ b/src/Git2/Version.hpp
@@ -6,10 +6,10 @@
 namespace git2 {
 
 struct Version {
-  int major{};
-  int minor{};
-  int rev{};
-  int features;
+  int mMajor{};
+  int mMinor{};
+  int mRev{};
+  int mFeatures;
 
   Version();
 

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -30,7 +30,7 @@ concept HeadProcessor = std::is_nothrow_invocable_v<Fn, std::string_view>
                         && Display<std::invoke_result_t<Fn, std::string_view>>;
 
 class Logger {
-  Level level = Level::Info;
+  Level mLevel = Level::Info;
 
   constexpr Logger() noexcept = default;
 
@@ -47,10 +47,10 @@ public:
     return instance;
   }
   static void setLevel(Level level) noexcept {
-    instance().level = level;
+    instance().mLevel = level;
   }
   static Level getLevel() noexcept {
-    return instance().level;
+    return instance().mLevel;
   }
 
   template <typename... Args>
@@ -151,7 +151,7 @@ private:
   void
   log(std::ostream& os, Level level, HeadProcessor auto&& processHead,
       auto&& head, fmt::format_string<Args...> fmt, Args&&... args) noexcept {
-    if (level <= this->level) {
+    if (level <= mLevel) {
       os << std::invoke(
           std::forward<decltype(processHead)>(processHead),
           std::forward<decltype(head)>(head)

--- a/src/Manifest.hpp
+++ b/src/Manifest.hpp
@@ -13,15 +13,15 @@
 #include <vector>
 
 struct DepMetadata {
-  std::string includes; // -Isomething
-  std::string libs; // -Lsomething -lsomething
+  std::string mIncludes; // -Isomething
+  std::string mLibs; // -Lsomething -lsomething
 };
 
 struct Profile {
-  std::unordered_set<std::string> cxxflags;
-  bool lto = false;
-  std::optional<bool> debug = std::nullopt;
-  std::optional<size_t> optLevel = std::nullopt;
+  std::unordered_set<std::string> mCxxflags;
+  bool mLto = false;
+  std::optional<bool> mDebug = std::nullopt;
+  std::optional<size_t> mOptLevel = std::nullopt;
 
   // Merges this profile with another profile. If a field in this profile is
   // set, it will not be overwritten by the other profile. Only default values
@@ -43,8 +43,8 @@ struct Edition {
   using enum Year;
 
 private:
-  Year edition = Year::Cpp20;
-  std::string str = "20";
+  Year mEdition = Year::Cpp20;
+  std::string mStr = "20";
 
 public:
   Edition() = default;
@@ -53,10 +53,10 @@ public:
   std::string getString() const noexcept;
 
   auto operator<=>(const Edition& otherEdition) const {
-    return edition <=> otherEdition.edition;
+    return mEdition <=> otherEdition.mEdition;
   }
   auto operator<=>(const Year& otherYear) const {
-    return edition <=> otherYear;
+    return mEdition <=> otherYear;
   }
 };
 

--- a/src/Parallelism.cc
+++ b/src/Parallelism.cc
@@ -30,13 +30,13 @@ struct ParallelismState {
       numThreads = 1;
     }
 
-    status = std::make_unique<tbb::global_control>(
+    mStatus = std::make_unique<tbb::global_control>(
         tbb::global_control::max_allowed_parallelism, numThreads
     );
   }
   size_t get() const noexcept {
     // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    return status->active_value(tbb::global_control::max_allowed_parallelism);
+    return mStatus->active_value(tbb::global_control::max_allowed_parallelism);
   }
 
   static ParallelismState& instance() noexcept {
@@ -45,10 +45,10 @@ struct ParallelismState {
   }
 
 private:
-  std::unique_ptr<tbb::global_control> status;
+  std::unique_ptr<tbb::global_control> mStatus;
 
   ParallelismState() noexcept
-      : status(std::make_unique<tbb::global_control>(
+      : mStatus(std::make_unique<tbb::global_control>(
             tbb::global_control::max_allowed_parallelism, numThreads()
         )) {}
 };

--- a/src/Semver.cc
+++ b/src/Semver.cc
@@ -12,12 +12,12 @@
 
 std::ostream&
 operator<<(std::ostream& os, const VersionToken& tok) noexcept {
-  switch (tok.kind) {
+  switch (tok.mKind) {
     case VersionToken::Num:
-      os << std::get<uint64_t>(tok.value);
+      os << std::get<uint64_t>(tok.mValue);
       break;
     case VersionToken::Ident:
-      os << std::get<std::string_view>(tok.value);
+      os << std::get<std::string_view>(tok.mValue);
       break;
     case VersionToken::Dot:
       os << '.';
@@ -49,15 +49,15 @@ VersionToken::size() const noexcept {
 
 bool
 operator==(const VersionToken& lhs, const VersionToken& rhs) noexcept {
-  if (lhs.kind != rhs.kind) {
+  if (lhs.mKind != rhs.mKind) {
     return false;
   }
-  switch (lhs.kind) {
+  switch (lhs.mKind) {
     case VersionToken::Num:
-      return std::get<uint64_t>(lhs.value) == std::get<uint64_t>(rhs.value);
+      return std::get<uint64_t>(lhs.mValue) == std::get<uint64_t>(rhs.mValue);
     case VersionToken::Ident:
-      return std::get<std::string_view>(lhs.value)
-             == std::get<std::string_view>(rhs.value);
+      return std::get<std::string_view>(lhs.mValue)
+             == std::get<std::string_view>(rhs.mValue);
     case VersionToken::Dot:
     case VersionToken::Hyphen:
     case VersionToken::Plus:
@@ -70,8 +70,8 @@ operator==(const VersionToken& lhs, const VersionToken& rhs) noexcept {
 
 bool
 operator<(const VersionToken& lhs, const VersionToken& rhs) noexcept {
-  if (lhs.kind == VersionToken::Num && rhs.kind == VersionToken::Num) {
-    return std::get<uint64_t>(lhs.value) < std::get<uint64_t>(rhs.value);
+  if (lhs.mKind == VersionToken::Num && rhs.mKind == VersionToken::Num) {
+    return std::get<uint64_t>(lhs.mValue) < std::get<uint64_t>(rhs.mValue);
   }
   return lhs.toString() < rhs.toString();
 }
@@ -82,7 +82,7 @@ operator>(const VersionToken& lhs, const VersionToken& rhs) {
 
 static std::string
 carets(const VersionToken& tok) noexcept {
-  switch (tok.kind) {
+  switch (tok.mKind) {
     case VersionToken::Eof:
     case VersionToken::Unknown:
       return "^";
@@ -94,24 +94,24 @@ carets(const VersionToken& tok) noexcept {
 
 bool
 Prerelease::empty() const noexcept {
-  return ident.empty();
+  return mIdent.empty();
 }
 
 std::string
 Prerelease::toString() const noexcept {
   std::string str;
-  for (size_t i = 0; i < ident.size(); ++i) {
+  for (size_t i = 0; i < mIdent.size(); ++i) {
     if (i > 0) {
       str += '.';
     }
-    str += ident[i].toString();
+    str += mIdent[i].toString();
   }
   return str;
 }
 
 bool
 operator==(const Prerelease& lhs, const Prerelease& rhs) noexcept {
-  return lhs.ident == rhs.ident;
+  return lhs.mIdent == rhs.mIdent;
 }
 bool
 operator!=(const Prerelease& lhs, const Prerelease& rhs) noexcept {
@@ -119,20 +119,20 @@ operator!=(const Prerelease& lhs, const Prerelease& rhs) noexcept {
 }
 bool
 operator<(const Prerelease& lhs, const Prerelease& rhs) noexcept {
-  if (lhs.ident.empty()) {
+  if (lhs.mIdent.empty()) {
     return false; // lhs is a normal version and is greater
   }
-  if (rhs.ident.empty()) {
+  if (rhs.mIdent.empty()) {
     return true; // rhs is a normal version and is greater
   }
-  for (size_t i = 0; i < lhs.ident.size() && i < rhs.ident.size(); ++i) {
-    if (lhs.ident[i] < rhs.ident[i]) {
+  for (size_t i = 0; i < lhs.mIdent.size() && i < rhs.mIdent.size(); ++i) {
+    if (lhs.mIdent[i] < rhs.mIdent[i]) {
       return true;
-    } else if (lhs.ident[i] > rhs.ident[i]) {
+    } else if (lhs.mIdent[i] > rhs.mIdent[i]) {
       return false;
     }
   }
-  return lhs.ident.size() < rhs.ident.size();
+  return lhs.mIdent.size() < rhs.mIdent.size();
 }
 bool
 operator>(const Prerelease& lhs, const Prerelease& rhs) noexcept {
@@ -149,35 +149,35 @@ operator>=(const Prerelease& lhs, const Prerelease& rhs) noexcept {
 
 bool
 BuildMetadata::empty() const noexcept {
-  return ident.empty();
+  return mIdent.empty();
 }
 
 std::string
 BuildMetadata::toString() const noexcept {
   std::string str;
-  for (size_t i = 0; i < ident.size(); ++i) {
+  for (size_t i = 0; i < mIdent.size(); ++i) {
     if (i > 0) {
       str += '.';
     }
-    str += ident[i].toString();
+    str += mIdent[i].toString();
   }
   return str;
 }
 
 bool
 operator==(const BuildMetadata& lhs, const BuildMetadata& rhs) noexcept {
-  return lhs.ident == rhs.ident;
+  return lhs.mIdent == rhs.mIdent;
 }
 bool
 operator<(const BuildMetadata& lhs, const BuildMetadata& rhs) noexcept {
-  for (size_t i = 0; i < lhs.ident.size() && i < rhs.ident.size(); ++i) {
-    if (lhs.ident[i] < rhs.ident[i]) {
+  for (size_t i = 0; i < lhs.mIdent.size() && i < rhs.mIdent.size(); ++i) {
+    if (lhs.mIdent[i] < rhs.mIdent[i]) {
       return true;
-    } else if (lhs.ident[i] > rhs.ident[i]) {
+    } else if (lhs.mIdent[i] > rhs.mIdent[i]) {
       return false;
     }
   }
-  return lhs.ident.size() < rhs.ident.size();
+  return lhs.mIdent.size() < rhs.mIdent.size();
 }
 bool
 operator>(const BuildMetadata& lhs, const BuildMetadata& rhs) noexcept {
@@ -186,16 +186,16 @@ operator>(const BuildMetadata& lhs, const BuildMetadata& rhs) noexcept {
 
 std::string
 Version::toString() const noexcept {
-  std::string str = std::to_string(major);
-  str += '.' + std::to_string(minor);
-  str += '.' + std::to_string(patch);
-  if (!pre.empty()) {
+  std::string str = std::to_string(mMajor);
+  str += '.' + std::to_string(mMinor);
+  str += '.' + std::to_string(mPatch);
+  if (!mPre.empty()) {
     str += '-';
-    str += pre.toString();
+    str += mPre.toString();
   }
-  if (!build.empty()) {
+  if (!mBuild.empty()) {
     str += '+';
-    str += build.toString();
+    str += mBuild.toString();
   }
   return str;
 }
@@ -208,9 +208,9 @@ operator<<(std::ostream& os, const Version& ver) noexcept {
 
 bool
 operator==(const Version& lhs, const Version& rhs) noexcept {
-  return lhs.major == rhs.major && lhs.minor == rhs.minor
-         && lhs.patch == rhs.patch && lhs.pre == rhs.pre
-         && lhs.build == rhs.build;
+  return lhs.mMajor == rhs.mMajor && lhs.mMinor == rhs.mMinor
+         && lhs.mPatch == rhs.mPatch && lhs.mPre == rhs.mPre
+         && lhs.mBuild == rhs.mBuild;
 }
 bool
 operator!=(const Version& lhs, const Version& rhs) noexcept {
@@ -219,32 +219,32 @@ operator!=(const Version& lhs, const Version& rhs) noexcept {
 
 bool
 operator<(const Version& lhs, const Version& rhs) noexcept {
-  if (lhs.major < rhs.major) {
+  if (lhs.mMajor < rhs.mMajor) {
     return true;
-  } else if (lhs.major > rhs.major) {
+  } else if (lhs.mMajor > rhs.mMajor) {
     return false;
-  } else if (lhs.minor < rhs.minor) {
+  } else if (lhs.mMinor < rhs.mMinor) {
     return true;
-  } else if (lhs.minor > rhs.minor) {
+  } else if (lhs.mMinor > rhs.mMinor) {
     return false;
-  } else if (lhs.patch < rhs.patch) {
+  } else if (lhs.mPatch < rhs.mPatch) {
     return true;
-  } else if (lhs.patch > rhs.patch) {
+  } else if (lhs.mPatch > rhs.mPatch) {
     return false;
-  } else if (!lhs.pre.empty() && rhs.pre.empty()) {
+  } else if (!lhs.mPre.empty() && rhs.mPre.empty()) {
     // lhs has a pre-release tag and rhs doesn't, so lhs < rhs
     return true;
-  } else if (lhs.pre.empty() && !rhs.pre.empty()) {
+  } else if (lhs.mPre.empty() && !rhs.mPre.empty()) {
     // lhs doesn't have a pre-release tag and rhs does, so lhs > rhs
     return false;
-  } else if (lhs.pre < rhs.pre) {
+  } else if (lhs.mPre < rhs.mPre) {
     // Both lhs and rhs have pre-release tags, so compare them
     return true;
-  } else if (lhs.pre > rhs.pre) {
+  } else if (lhs.mPre > rhs.mPre) {
     return false;
-  } else if (lhs.build < rhs.build) {
+  } else if (lhs.mBuild < rhs.mBuild) {
     return true;
-  } else if (lhs.build > rhs.build) {
+  } else if (lhs.mBuild > rhs.mBuild) {
     return false;
   } else {
     return false;
@@ -266,30 +266,30 @@ operator>=(const Version& lhs, const Version& rhs) noexcept {
 VersionToken
 VersionLexer::consumeIdent() noexcept {
   size_t len = 0;
-  while (pos < s.size() && (std::isalnum(s[pos]) || s[pos] == '-')) {
+  while (mPos < mS.size() && (std::isalnum(mS[mPos]) || mS[mPos] == '-')) {
     step();
     ++len;
   }
-  return { VersionToken::Ident, std::string_view(s.data() + pos - len, len) };
+  return { VersionToken::Ident, std::string_view(mS.data() + mPos - len, len) };
 }
 
 VersionToken
 VersionLexer::consumeNum() {
   size_t len = 0;
   uint64_t value = 0;
-  while (pos < s.size() && std::isdigit(s[pos])) {
+  while (mPos < mS.size() && std::isdigit(mS[mPos])) {
     if (len > 0 && value == 0) {
       throw SemverError(
-          s, '\n', std::string(pos - len, ' '), "^ invalid leading zero"
+          mS, '\n', std::string(mPos - len, ' '), "^ invalid leading zero"
       );
     }
 
-    const uint64_t digit = s[pos] - '0';
+    const uint64_t digit = mS[mPos] - '0';
     constexpr uint64_t base = 10;
     // Check for overflow
     if (value > (std::numeric_limits<uint64_t>::max() - digit) / base) {
       throw SemverError(
-          s, '\n', std::string(pos - len, ' '), std::string(len, '^'),
+          mS, '\n', std::string(mPos - len, ' '), std::string(len, '^'),
           " number exceeds UINT64_MAX"
       );
     }
@@ -304,16 +304,16 @@ VersionLexer::consumeNum() {
 // Note that 012 is an invalid number but 012d is a valid identifier.
 VersionToken
 VersionLexer::consumeNumOrIdent() {
-  const size_t oldPos = pos; // we need two passes
+  const size_t oldPos = mPos; // we need two passes
   bool isIdent = false;
-  while (pos < s.size() && (std::isalnum(s[pos]) || s[pos] == '-')) {
-    if (!std::isdigit(s[pos])) {
+  while (mPos < mS.size() && (std::isalnum(mS[mPos]) || mS[mPos] == '-')) {
+    if (!std::isdigit(mS[mPos])) {
       isIdent = true;
     }
     step();
   }
 
-  pos = oldPos;
+  mPos = oldPos;
   if (isIdent) {
     return consumeIdent();
   } else {
@@ -327,7 +327,7 @@ VersionLexer::next() {
     return VersionToken{ VersionToken::Eof };
   }
 
-  const char c = s[pos];
+  const char c = mS[mPos];
   if (std::isalpha(c)) {
     return consumeIdent();
   } else if (std::isdigit(c)) {
@@ -349,9 +349,9 @@ VersionLexer::next() {
 
 VersionToken
 VersionLexer::peek() {
-  const size_t oldPos = pos;
+  const size_t oldPos = mPos;
   const VersionToken tok = next();
-  pos = oldPos;
+  mPos = oldPos;
   return tok;
 }
 
@@ -361,41 +361,42 @@ struct SemverParseError : public SemverError {
       const std::string_view msg
   )
       : SemverError(
-            lexer.s, '\n', std::string(lexer.pos, ' '), carets(tok), msg
+            lexer.mS, '\n', std::string(lexer.mPos, ' '), carets(tok), msg
         ) {}
 };
 
 Version
 VersionParser::parse() {
-  if (lexer.peek().kind == VersionToken::Eof) {
+  if (mLexer.peek().mKind == VersionToken::Eof) {
     throw SemverError("empty string is not a valid semver");
   }
 
   Version ver;
-  ver.major = parseNum();
+  ver.mMajor = parseNum();
   parseDot();
-  ver.minor = parseNum();
+  ver.mMinor = parseNum();
   parseDot();
-  ver.patch = parseNum();
+  ver.mPatch = parseNum();
 
-  if (lexer.peek().kind == VersionToken::Hyphen) {
-    lexer.step();
-    ver.pre = parsePre();
+  if (mLexer.peek().mKind == VersionToken::Hyphen) {
+    mLexer.step();
+    ver.mPre = parsePre();
   } else {
-    ver.pre = Prerelease();
+    ver.mPre = Prerelease();
   }
 
-  if (lexer.peek().kind == VersionToken::Plus) {
-    lexer.step();
-    ver.build = parseBuild();
+  if (mLexer.peek().mKind == VersionToken::Plus) {
+    mLexer.step();
+    ver.mBuild = parseBuild();
   } else {
-    ver.build = BuildMetadata();
+    ver.mBuild = BuildMetadata();
   }
 
-  if (!lexer.isEof()) {
+  if (!mLexer.isEof()) {
     throw SemverParseError(
-        lexer, lexer.peek(),
-        " unexpected character: `" + std::string(1, lexer.s[lexer.pos]) + '`'
+        mLexer, mLexer.peek(),
+        " unexpected character: `" + std::string(1, mLexer.mS[mLexer.mPos])
+            + '`'
     );
   }
 
@@ -406,17 +407,17 @@ VersionParser::parse() {
 // number.
 uint64_t
 VersionParser::parseNum() {
-  if (!std::isdigit(lexer.s[lexer.pos])) {
-    throw SemverParseError(lexer, lexer.peek(), " expected number");
+  if (!std::isdigit(mLexer.mS[mLexer.mPos])) {
+    throw SemverParseError(mLexer, mLexer.peek(), " expected number");
   }
-  return std::get<uint64_t>(lexer.consumeNum().value);
+  return std::get<uint64_t>(mLexer.consumeNum().mValue);
 }
 
 void
 VersionParser::parseDot() {
-  const VersionToken tok = lexer.next();
-  if (tok.kind != VersionToken::Dot) {
-    throw SemverParseError(lexer, tok, " expected `.`");
+  const VersionToken tok = mLexer.next();
+  if (tok.mKind != VersionToken::Dot) {
+    throw SemverParseError(mLexer, tok, " expected `.`");
   }
 }
 
@@ -425,8 +426,8 @@ Prerelease
 VersionParser::parsePre() {
   std::vector<VersionToken> pre;
   pre.emplace_back(parseNumOrIdent());
-  while (lexer.peek().kind == VersionToken::Dot) {
-    lexer.step();
+  while (mLexer.peek().mKind == VersionToken::Dot) {
+    mLexer.step();
     pre.emplace_back(parseNumOrIdent());
   }
   return Prerelease{ pre };
@@ -435,9 +436,9 @@ VersionParser::parsePre() {
 // numOrIdent ::= num | ident
 VersionToken
 VersionParser::parseNumOrIdent() {
-  const VersionToken tok = lexer.next();
-  if (tok.kind != VersionToken::Num && tok.kind != VersionToken::Ident) {
-    throw SemverParseError(lexer, tok, " expected number or identifier");
+  const VersionToken tok = mLexer.next();
+  if (tok.mKind != VersionToken::Num && tok.mKind != VersionToken::Ident) {
+    throw SemverParseError(mLexer, tok, " expected number or identifier");
   }
   return tok;
 }
@@ -447,8 +448,8 @@ BuildMetadata
 VersionParser::parseBuild() {
   std::vector<VersionToken> build;
   build.emplace_back(parseIdent());
-  while (lexer.peek().kind == VersionToken::Dot) {
-    lexer.step();
+  while (mLexer.peek().mKind == VersionToken::Dot) {
+    mLexer.step();
     build.emplace_back(parseIdent());
   }
   return BuildMetadata{ build };
@@ -458,10 +459,10 @@ VersionParser::parseBuild() {
 // identifier.
 VersionToken
 VersionParser::parseIdent() {
-  if (!std::isalnum(lexer.s[lexer.pos])) {
-    throw SemverParseError(lexer, lexer.peek(), " expected identifier");
+  if (!std::isalnum(mLexer.mS[mLexer.mPos])) {
+    throw SemverParseError(mLexer, mLexer.peek(), " expected identifier");
   }
-  return lexer.consumeIdent();
+  return mLexer.consumeIdent();
 }
 
 Prerelease
@@ -590,75 +591,75 @@ testParse() {
   );
 
   assertEq(
-      Version::parse("1.2.3"), (Version{ .major = 1,
-                                         .minor = 2,
-                                         .patch = 3,
-                                         .pre = Prerelease(),
-                                         .build = BuildMetadata() })
+      Version::parse("1.2.3"), (Version{ .mMajor = 1,
+                                         .mMinor = 2,
+                                         .mPatch = 3,
+                                         .mPre = Prerelease(),
+                                         .mBuild = BuildMetadata() })
   );
   assertEq(
       Version::parse("1.2.3-alpha1"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease::parse("alpha1"),
-                .build = BuildMetadata() })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease::parse("alpha1"),
+                .mBuild = BuildMetadata() })
   );
   assertEq(
       Version::parse("1.2.3+build5"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease(),
-                .build = BuildMetadata::parse("build5") })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease(),
+                .mBuild = BuildMetadata::parse("build5") })
   );
   assertEq(
       Version::parse("1.2.3+5build"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease(),
-                .build = BuildMetadata::parse("5build") })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease(),
+                .mBuild = BuildMetadata::parse("5build") })
   );
   assertEq(
       Version::parse("1.2.3-alpha1+build5"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease::parse("alpha1"),
-                .build = BuildMetadata::parse("build5") })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease::parse("alpha1"),
+                .mBuild = BuildMetadata::parse("build5") })
   );
   assertEq(
       Version::parse("1.2.3-1.alpha1.9+build5.7.3aedf"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease::parse("1.alpha1.9"),
-                .build = BuildMetadata::parse("build5.7.3aedf") })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease::parse("1.alpha1.9"),
+                .mBuild = BuildMetadata::parse("build5.7.3aedf") })
   );
   assertEq(
       Version::parse("1.2.3-0a.alpha1.9+05build.7.3aedf"),
-      (Version{ .major = 1,
-                .minor = 2,
-                .patch = 3,
-                .pre = Prerelease::parse("0a.alpha1.9"),
-                .build = BuildMetadata::parse("05build.7.3aedf") })
+      (Version{ .mMajor = 1,
+                .mMinor = 2,
+                .mPatch = 3,
+                .mPre = Prerelease::parse("0a.alpha1.9"),
+                .mBuild = BuildMetadata::parse("05build.7.3aedf") })
   );
   assertEq(
       Version::parse("0.4.0-beta.1+0851523"),
-      (Version{ .major = 0,
-                .minor = 4,
-                .patch = 0,
-                .pre = Prerelease::parse("beta.1"),
-                .build = BuildMetadata::parse("0851523") })
+      (Version{ .mMajor = 0,
+                .mMinor = 4,
+                .mPatch = 0,
+                .mPre = Prerelease::parse("beta.1"),
+                .mBuild = BuildMetadata::parse("0851523") })
   );
   assertEq(
       Version::parse("1.1.0-beta-10"),
-      (Version{ .major = 1,
-                .minor = 1,
-                .patch = 0,
-                .pre = Prerelease::parse("beta-10"),
-                .build = BuildMetadata() })
+      (Version{ .mMajor = 1,
+                .mMinor = 1,
+                .mPatch = 0,
+                .mPre = Prerelease::parse("beta-10"),
+                .mBuild = BuildMetadata() })
   );
 
   pass();

--- a/src/Semver.hpp
+++ b/src/Semver.hpp
@@ -37,23 +37,23 @@ struct VersionToken {
   };
   using enum Kind;
 
-  Kind kind;
-  std::variant<std::monostate, uint64_t, std::string_view> value;
+  Kind mKind;
+  std::variant<std::monostate, uint64_t, std::string_view> mValue;
 
   constexpr VersionToken(
       Kind kind,
       const std::variant<std::monostate, uint64_t, std::string_view>& value
   ) noexcept
-      : kind(kind), value(value) {}
+      : mKind(kind), mValue(value) {}
   constexpr explicit VersionToken(Kind kind) noexcept
-      : kind(kind), value(std::monostate{}) {}
+      : mKind(kind), mValue(std::monostate{}) {}
 
   std::string toString() const noexcept;
   size_t size() const noexcept;
 };
 
 struct Prerelease {
-  std::vector<VersionToken> ident;
+  std::vector<VersionToken> mIdent;
 
   static Prerelease parse(std::string_view str);
   bool empty() const noexcept;
@@ -67,7 +67,7 @@ bool operator<=(const Prerelease& lhs, const Prerelease& rhs) noexcept;
 bool operator>=(const Prerelease& lhs, const Prerelease& rhs) noexcept;
 
 struct BuildMetadata {
-  std::vector<VersionToken> ident;
+  std::vector<VersionToken> mIdent;
 
   static BuildMetadata parse(std::string_view str);
   bool empty() const noexcept;
@@ -75,11 +75,11 @@ struct BuildMetadata {
 };
 
 struct Version {
-  uint64_t major{};
-  uint64_t minor{};
-  uint64_t patch{};
-  Prerelease pre;
-  BuildMetadata build;
+  uint64_t mMajor{};
+  uint64_t mMinor{};
+  uint64_t mPatch{};
+  Prerelease mPre;
+  BuildMetadata mBuild;
 
   static Version parse(std::string_view str);
   std::string toString() const noexcept;
@@ -93,17 +93,17 @@ bool operator<=(const Version& lhs, const Version& rhs) noexcept;
 bool operator>=(const Version& lhs, const Version& rhs) noexcept;
 
 struct VersionLexer {
-  std::string_view s;
-  size_t pos{ 0 };
+  std::string_view mS;
+  size_t mPos{ 0 };
 
   constexpr explicit VersionLexer(const std::string_view str) noexcept
-      : s(str) {}
+      : mS(str) {}
 
   constexpr bool isEof() const noexcept {
-    return pos >= s.size();
+    return mPos >= mS.size();
   }
   constexpr void step() noexcept {
-    ++pos;
+    ++mPos;
   }
   VersionToken consumeIdent() noexcept;
   VersionToken consumeNum();
@@ -113,10 +113,10 @@ struct VersionLexer {
 };
 
 struct VersionParser {
-  VersionLexer lexer;
+  VersionLexer mLexer;
 
   constexpr explicit VersionParser(const std::string_view str) noexcept
-      : lexer(str) {}
+      : mLexer(str) {}
 
   Version parse();
   uint64_t parseNum();

--- a/src/TermColor.cc
+++ b/src/TermColor.cc
@@ -37,18 +37,18 @@ struct ColorState {
   void set(const ColorMode mode) noexcept {
     switch (mode) {
       case ColorMode::Always:
-        state = true;
+        mState = true;
         return;
       case ColorMode::Auto:
-        state = isTerm();
+        mState = isTerm();
         return;
       case ColorMode::Never:
-        state = false;
+        mState = false;
         return;
     }
   }
   bool shouldColor() const noexcept {
-    return state;
+    return mState;
   }
 
   static ColorState& instance() noexcept {
@@ -58,13 +58,13 @@ struct ColorState {
 
 private:
   // default: automatic
-  bool state;
+  bool mState;
 
   ColorState() noexcept {
     if (const char* color = std::getenv("POAC_TERM_COLOR")) {
       set(getColorMode(color));
     } else {
-      state = isTerm();
+      mState = isTerm();
     }
   }
 };

--- a/src/VersionReq.hpp
+++ b/src/VersionReq.hpp
@@ -23,10 +23,10 @@
 #include <string_view>
 
 struct OptVersion {
-  uint64_t major{};
-  std::optional<uint64_t> minor;
-  std::optional<uint64_t> patch;
-  Prerelease pre;
+  uint64_t mMajor{};
+  std::optional<uint64_t> mMinor;
+  std::optional<uint64_t> mPatch;
+  Prerelease mPre;
 };
 
 // 1. NoOp: (Caret (^), "compatible" updates)
@@ -71,11 +71,11 @@ struct Comparator {
   };
   using enum Op;
 
-  std::optional<Op> op;
-  uint64_t major{};
-  std::optional<uint64_t> minor;
-  std::optional<uint64_t> patch;
-  Prerelease pre;
+  std::optional<Op> mOp;
+  uint64_t mMajor{};
+  std::optional<uint64_t> mMinor;
+  std::optional<uint64_t> mPatch;
+  Prerelease mPre;
 
   static Comparator parse(std::string_view str);
   void from(const OptVersion& ver) noexcept;
@@ -86,8 +86,8 @@ struct Comparator {
 };
 
 struct VersionReq {
-  Comparator left;
-  std::optional<Comparator> right;
+  Comparator mLeft;
+  std::optional<Comparator> mRight;
 
   static VersionReq parse(std::string_view str);
   bool satisfiedBy(const Version& ver) const noexcept;


### PR DESCRIPTION
Related to:
* https://github.com/poac-dev/poac/pull/1035#discussion_r1843078361
* https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly
* https://llvm.org/docs/Proposals/VariableNames.html