### PR TITLE
lint: support cpplint 2.0

### DIFF
--- a/poac.toml
+++ b/poac.toml
@@ -27,6 +27,7 @@ lto = true
 [lint.cpplint]
 filters = [
   "-build/c++11",
+  "-build/c++17",
   "-build/include_order", # prioritize clang-format
   "-build/include_subdir",
   "-legal/copyright",

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fcntl.h>
+#include <string>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>


### PR DESCRIPTION
Current `poac` code fails `poac lint` with `cpplint` 2.0.0. This PR fixes this:

```console
$ cpplint --version
Cpplint fork (https://github.com/cpplint/cpplint)
cpplint 2.0.0
Python 3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]
$ poac-out/debug/poac lint --exclude srcOld --exclude testsOld
   Linting poac
src/BuildConfig.cc:19:  <filesystem> is an unapproved C++17 header.  [build/c++17] [5]
Done processing src/BuildConfig.cc
src/Command.cc:235:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing src/Command.cc
src/Command.hpp:4:  <filesystem> is an unapproved C++17 header.  [build/c++17] [5]
Done processing src/Command.hpp
src/Rustify/Aliases.hpp:4:  <filesystem> is an unapproved C++17 header.  [build/c++17] [5]
Done processing src/Rustify/Aliases.hpp
Total errors found: 4
Error: 'poac lint' failed with exit code `1`
```