### PR TITLE
Fix issue that build will be succeeded even if code is corrupted with `poac build` twice

### DIFF
--- a/src/BuildConfig.cc
+++ b/src/BuildConfig.cc
@@ -951,6 +951,7 @@ emitMakefile(const bool isDebug, const bool includeDevDeps) {
   // When emitting Makefile, we also build the project.  So, we need to
   // make sure the dependencies are installed.
   config.installDeps(includeDevDeps);
+  config.configureBuild();
 
   const std::string makefilePath = config.outBasePath / "Makefile";
   if (isUpToDate(makefilePath)) {
@@ -959,7 +960,6 @@ emitMakefile(const bool isDebug, const bool includeDevDeps) {
   }
   logger::debug("Makefile is NOT up to date");
 
-  config.configureBuild();
   std::ofstream ofs(makefilePath);
   config.emitMakefile(ofs);
   return config;


### PR DESCRIPTION
Current poac skip entire build job if `Makefile` is up to date.
So, when we do `poac build` twice, second try must returns succeeded despite doing nothing.
This PR fixes this.

```console
$ poac new test
   Created binary (application) `
$ cd test/
$ echo "" > src/main.cc
$ poac build
 Compiling test v0.1.0 (/path/to/test)
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/14/../../../x86_64-linux-gnu/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
collect2: error: ld returned 1 exit status
make: *** [Makefile:21: /path/to/test/poac-out/debug/test] Error 1
Error: 'poac build' failed with exit code `2`
$ poac build
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
```